### PR TITLE
Feat working confirmation

### DIFF
--- a/app.go
+++ b/app.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/theBGuy/go-work-tracker/auto_update"
+	"github.com/wailsapp/wails/v2/pkg/runtime"
 
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -216,6 +217,10 @@ func (a *App) TimeElapsed() int {
 		return int(time.Since(a.startTime).Seconds())
 	}
 	return 0
+}
+
+func (a *App) ShowWindow() {
+	runtime.WindowShow(a.ctx)
 }
 
 // GetWorkTime returns the total seconds worked

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -297,7 +297,7 @@ function App() {
         ShowWindow().then(() => {
           setOpenConfirm(true);
         });
-      }, 1000 * 60 * 0.30); // Show the alert every 30 minutes - TODO: make this configurable
+      }, 1000 * 60 * 30); // Show the alert every 30 minutes - TODO: make this configurable
     }
 
     return () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -51,7 +51,8 @@ import {
   GetYearlyWorkTime,
   GetMonthlyWorkTime,
   GetVersion,
-  UpdateAvailable
+  UpdateAvailable,
+  ShowWindow
 } from "../wailsjs/go/main/App";
 
 function App() {
@@ -293,8 +294,10 @@ function App() {
 
     if (timerRunning && !openConfirm) {
       interval = setInterval(() => {
-        setOpenConfirm(true);
-      }, 1000 * 60 * 30); // Show the alert every 30 minutes - TODO: make this configurable
+        ShowWindow().then(() => {
+          setOpenConfirm(true);
+        });
+      }, 1000 * 60 * 0.30); // Show the alert every 30 minutes - TODO: make this configurable
     }
 
     return () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -234,9 +234,19 @@ function App() {
     if (newAlertTime !== alertTime) {
       setAlertTime(newAlertTime);
       if (newAlertTime === 0) {
-        toast.success("Settings updated! Alert time disabled");
+        toast.success(
+          <div>
+            Settings updated! <br />
+            `Are you still working?` notification disabled
+          </div>
+        );
       } else {
-        toast.success("Settings updated! Alert time set to " + newAlertTime + " minutes");
+        toast.success(
+          <div>
+            Settings updated! <br />
+            `Are you still working?` interval set to every {newAlertTime} minutes
+          </div>
+        );
       }
     }
   };
@@ -476,12 +486,12 @@ function App() {
         <DialogTitle>Settings</DialogTitle>
         <DialogContent>
           <DialogContentText>
-            Set the interval for the popup that confirms if you're still working.
+            Set the time interval for the `Are you still working?` notification.
           </DialogContentText>
 
           {/* TODO: Are there other configurable settings we need? */}
           
-          <FormControl fullWidth sx={{ mt: 1 }}>
+          <FormControl fullWidth sx={{ mt: 2 }}>
             {/* Dropdown to select alert time interval */}
             <InputLabel id="alert-time-select">Confirmation Popup Interval (minutes)</InputLabel>
             <Select
@@ -491,7 +501,7 @@ function App() {
               autoWidth
               onChange={(event) => setNewAlertTime(event.target.value as number)}
             >
-              {[0, 5, 10, 15, 30, 60].map((minutes) => (
+              {[0, 1, 5, 10, 15, 30, 60].map((minutes) => (
                 <MenuItem key={minutes} value={minutes}>
                   {minutes}
                 </MenuItem>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -64,6 +64,7 @@ function App() {
   const [workTime, setWorkTime] = useState(0);
   const [elapsedTime, setElapsedTime] = useState(0);
   const elapsedTimeRef = useRef(elapsedTime);
+  const [openConfirm, setOpenConfirm] = useState(false);
 
   useEffect(() => {
     GetVersion().then(setVersion);
@@ -171,6 +172,7 @@ function App() {
       .then(setMonthlyWorkTimes);
     setTimerRunning(false);
     setElapsedTime(0);
+    setOpenConfirm(false);
   };
   
   const exportYearlyCSV = () => {
@@ -286,42 +288,34 @@ function App() {
     }
   }, [timerRunning]);
 
-  // const handleConfirm = () => {
-  //   const timeout = setTimeout(() => {
-  //     alert("You didn't confirm within two minutes. The timer will be stopped.");
-  //     stopTimer();
-  //   }, 1000 * 60 * 2);
+  useEffect(() => {
+    let interval: number | null | undefined = null;
 
-  //   if (window.confirm("Are you still working?")) {
-  //     console.log("User is still working");
-  //     clearTimeout(timeout);
-  //   } else {
-  //     console.log("User is not working");
-  //     clearTimeout(timeout);
-  //     stopTimer();
-  //   }
-  // }
+    if (timerRunning && !openConfirm) {
+      interval = setInterval(() => {
+        setOpenConfirm(true);
+      }, 1000 * 60 * 30); // Show the alert every 30 minutes - TODO: make this configurable
+    }
 
-  // useEffect(() => {
-  //   if (timerRunning) {
-  //     const interval = setInterval(() => {
-  //       setOpenConfirm(true);
-  //       return () => clearInterval(interval);
-  //     }, 1000 * 60 * 0.30); // Show the alert every hour
-  //   }
-  // }, [timerRunning]);
+    return () => {
+      if (interval) {
+        clearInterval(interval);
+      }
+    };
+}, [timerRunning, openConfirm]);
 
-  // useEffect(() => {
-  //   if (openConfirm) {
-  //     const timeout = setTimeout(() => {
-  //       if (timerRunning) {
-  //         alert("You didn't confirm within two minutes. The timer will be stopped.");
-  //         stopTimer();
-  //       }
-  //     }, 1000 * 60 * 0.30);
-  //     return () => clearTimeout(timeout);
-  //   }
-  // }, [openConfirm]);
+  useEffect(() => {
+    // TODO: maybe some sort of sound alert? or a notification? In case the user is not looking at the app
+    if (openConfirm) {
+      const timeout = setTimeout(() => {
+        if (timerRunning) {
+          stopTimer();
+          alert("You didn't confirm within two minutes. The timer will be stopped.");
+        }
+      }, 1000 * 60 * 2);
+      return () => clearTimeout(timeout);
+    }
+  }, [openConfirm]);
 
   return (
     <div id="App">
@@ -429,7 +423,7 @@ function App() {
       </Accordion>
 
       {/* Handle confirming user still active */}
-      {/* <Dialog
+      <Dialog
         disableEscapeKeyDown
         open={openConfirm}
         onClose={() => setOpenConfirm(false)}
@@ -437,9 +431,9 @@ function App() {
         <DialogTitle>Are you still working?</DialogTitle>
         <DialogActions>
           <Button onClick={() => setOpenConfirm(false)}>Yes</Button>
-          <Button onClick={() => setOpenConfirm(false)}>No</Button>
+          <Button onClick={() => stopTimer()}>No</Button>
         </DialogActions>
-      </Dialog> */}
+      </Dialog>
       
       {/* Handle creating a new organization */}
       <Dialog

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -26,6 +26,8 @@ export function RenameOrganization(arg1:string,arg2:string):Promise<void>;
 
 export function SetOrganization(arg1:string):Promise<void>;
 
+export function ShowWindow():Promise<void>;
+
 export function StartTimer(arg1:string):Promise<void>;
 
 export function StopTimer(arg1:string):Promise<void>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -50,6 +50,10 @@ export function SetOrganization(arg1) {
   return window['go']['main']['App']['SetOrganization'](arg1);
 }
 
+export function ShowWindow() {
+  return window['go']['main']['App']['ShowWindow']();
+}
+
 export function StartTimer(arg1) {
   return window['go']['main']['App']['StartTimer'](arg1);
 }


### PR DESCRIPTION
### Description:
Display a dialog every x minutes that prompts the user to confirm yes or no to if they are still working. If the dialog triggers and the user doesn't interact with it within 2 minutes, stop the timer. The interval is configurable through the settings dialog opened through the user menu dropdown. 

### Commits & Changes
- Backend
  - Added new `ShowWindow` method that uses the wails runtime package to bring the window to the front or open it if it was minimized
- Frontend
  - Add settings dialog to make the `still working` interval time configurable
  - Change `openDialog` -> `openNewOrg` it isn't the only `Dialog` component we have anymore
  - Modify `handleMenuClose` method to close any of the open dialog components

### Screenshots
![user-menu](https://github.com/theBGuy/go-work-tracker/assets/60308670/99e206db-89b5-463b-a8b2-ed008f6ad7b9)
![settings-dialog](https://github.com/theBGuy/go-work-tracker/assets/60308670/3fba224a-17aa-42ba-9d92-04d10fe97cc2)
![updated-time-notif](https://github.com/theBGuy/go-work-tracker/assets/60308670/d39fd638-5849-4472-bc8b-97b1da06c475)
![still-working-dialog](https://github.com/theBGuy/go-work-tracker/assets/60308670/65a24244-adb7-4180-aeeb-c2d2bf35212c)

