### PR TITLE
[BugFix] Use util `getMonth` to get the correct month

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -408,31 +408,35 @@ function App() {
           >
             {projects.map((project) => (
               <MenuItem key={project} value={project} sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                {project}
-                <Tooltip title="Edit project">
-                  <IconButton
-                    edge="end"
-                    aria-label="edit"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      handleOpenRenameProj();
-                    }}
-                  >
-                    <EditIcon />
-                  </IconButton>
-                </Tooltip>
-                <Tooltip title="Delete project">
-                  <IconButton
-                    edge="end"
-                    aria-label="delete"
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      handleDeleteProject(project);
-                    }}
-                  >
-                    <DeleteIcon />
-                  </IconButton>
-                </Tooltip>
+                <div>
+                  {project}
+                </div>
+                <div>
+                  <Tooltip title="Edit project">
+                    <IconButton
+                      edge="end"
+                      aria-label="edit"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        handleOpenRenameProj();
+                      }}
+                    >
+                      <EditIcon />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Delete project">
+                    <IconButton
+                      edge="end"
+                      aria-label="delete"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        handleDeleteProject(project);
+                      }}
+                    >
+                      <DeleteIcon />
+                    </IconButton>
+                  </Tooltip>
+                </div>
               </MenuItem>
             ))}
           </Select>

--- a/frontend/src/components/NewProjectDialog.tsx
+++ b/frontend/src/components/NewProjectDialog.tsx
@@ -9,6 +9,7 @@ import {
   TextField
 } from '@mui/material';
 import { NewProject, SetProject } from '../../wailsjs/go/main/App';
+import { getMonth } from "../utils/utils";
 
 interface NewProjectDialogProps {
   openNewProj: boolean;
@@ -42,8 +43,7 @@ const NewProjectDialog: React.FC<NewProjectDialogProps> = ({
     setProjects(projs => [...projs, project]);
     setSelectedProject(project);
     setMonthlyWorkTimes(prev => {
-      const currMonth = new Date().getMonth();
-      prev[currMonth][project] = 0;
+      prev[getMonth()][project] = 0;
       return { ...prev };
     });
     setOpenNewProj(false);


### PR DESCRIPTION
### Description:
Fixes invalid month caused by js's implementation of 0 based months. Fixes a style bug due to `space-between` css prop
### 🛠 Related Issues:
Reference any related issues using the syntax: "Fixes #123", "Addresses #456"

### 🧠 Rationale behind the change
Using go's month implementation is easier to keep track of.

### Commits & Changes:
- `App.tsx`
  - Fixed styling issue on projects dropdown caused by css property `space-between`
  - Added <some new feature>
  - Changed <some method> -> <new method>
- `NewProjectDialog.tsx`
  - Fixed `setMonthlyWorkTimes` to use `getMonth` from the utils module

### 📸 Screenshots (optional)

| Before | After |
|--------|-------|
| ![image](https://github.com/theBGuy/go-work-tracker/assets/60308670/e23351a2-2305-43e7-819f-570df7e11c59) |![after](https://github.com/theBGuy/go-work-tracker/assets/60308670/bb33aaad-306c-4058-9d30-684e3986e1fd) |

### 🏎 Quality check

- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?

- [x] Walk away, take a break, re-read what you filled out above does it make sense if you were coming in cold? What extra context could you provide?