### PR TITLE
[Feat] Normalize database

### DIFF
--- a/app.go
+++ b/app.go
@@ -189,3 +189,11 @@ func (a *App) ConfirmAction(title string, message string) bool {
 	}
 	return selection == "Yes"
 }
+
+func (a *App) SetProject(project string) {
+	if a.isRunning {
+		a.StopTimer(a.organization, a.project)
+	}
+	fmt.Println("Project set to:", project, "for Organization:", a.organization)
+	a.project = project
+}

--- a/csv_helper.go
+++ b/csv_helper.go
@@ -69,7 +69,7 @@ func (a *App) exportCSVByMonth(organization string, year int, month time.Month) 
 	writer.Write([]string{})
 	writer.Write([]string{"Weekly breakdown"})
 	writer.Write([]string{"Week", "Project", "Hours", "Time (HH:MM:SS)"})
-	for week := 0; week <= 4; week++ {
+	for week := 1; week <= 5; week++ {
 		projectTotals, ok := MonthlyTotals.WeeklyTotals[week]
 		if !ok {
 			continue

--- a/pdf_helper.go
+++ b/pdf_helper.go
@@ -121,7 +121,7 @@ func (a *App) exportPDFByMonth(organization string, year int, month time.Month) 
 	weekRanges := getWeekRanges(year, month)
 
 	// Write weekly totals
-	for week := 0; week <= 4; week++ {
+	for week := 1; week <= 5; week++ {
 		projectTotals, ok := MonthlyTotals.WeeklyTotals[week]
 		if !ok {
 			continue


### PR DESCRIPTION
Update-Type: [Minor]

### Description:
Normalizes the database, breaks the mono-table structure into three new tables for `Organizations`, `Projects`, and `WorkHours`. Each organization has projects and each project has workhours.

### 🧠 Rationale behind the change
The old structure with having only a single data with no relationships meant a lot of repeat data and extra read/writes when things were changed. This made it difficult to add any new columns.

### Commits & Changes:

- `helpers.go`
  - Re-wrote `fixOutdatedDb` method for this structure change, compatible with both previous versions of the database
  - Changed `getWeekRanges` and `GetWeekOfMonth` to start at 1 instead of being 0 indexed
- `db.go`
  - Created two new tables `projects` and `organizations`. Related them as each organization can have projects and each project has workhours

### 🏎 Quality check

- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?

- [x] Walk away, take a break, re-read what you filled out above does it make sense if you were coming in cold? What extra context could you provide?