### PR TITLE
[Feat] Favorite/Star Organizations and Projects

### DIFF
--- a/db.go
+++ b/db.go
@@ -323,7 +323,6 @@ func (a *App) GetProjects(organizationName string) (projects []Project, err erro
 	}
 
 	// Get the projects within the organization
-	// var projectModels []Project
 	err = a.db.
 		Where("projects.deleted_at IS NULL"). // Ignore deleted projects
 		Where(&Project{OrganizationID: organization.ID}).
@@ -331,12 +330,6 @@ func (a *App) GetProjects(organizationName string) (projects []Project, err erro
 	if err != nil {
 		return nil, err
 	}
-
-	// Extract the project names
-	// projects = make([]string, len(projectModels))
-	// for i, project := range projectModels {
-	// 	projects[i] = project.Name
-	// }
 
 	return projects, nil
 }
@@ -377,16 +370,9 @@ func (a *App) DeleteOrganization(organizationName string) {
 	}
 }
 
-func (a *App) GetOrganizations() (organizations []string, err error) {
-	var organizationModels []Organization
-	if err := a.db.Find(&organizationModels).Where("organizations.deleted_at IS NULL").Error; err != nil {
+func (a *App) GetOrganizations() (organizations []Organization, err error) {
+	if err := a.db.Find(&organizations).Where("organizations.deleted_at IS NULL").Error; err != nil {
 		return nil, err
-	}
-
-	// Extract the organization names
-	organizations = make([]string, len(organizationModels))
-	for i, organization := range organizationModels {
-		organizations[i] = organization.Name
 	}
 
 	return organizations, nil

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,6 +38,8 @@ import MenuIcon from '@mui/icons-material/Menu';
 import SettingsIcon from '@mui/icons-material/Settings';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
+import StarIcon from '@mui/icons-material/Star';
+import StarBorderIcon from '@mui/icons-material/StarBorder';
 import {
   StartTimer,
   StopTimer,
@@ -54,9 +56,10 @@ import {
   DeleteProject,
   ShowWindow,
   ConfirmAction,
+  ToggleFavoriteProject,
 } from "../wailsjs/go/main/App";
 
-import { getMonth, months, formatTime, dateString, getCurrentWeekOfMonth } from './utils/utils'
+import { getMonth, months, formatTime, dateString, getCurrentWeekOfMonth, Project } from './utils/utils'
 import EditProjectDialog from './components/EditProjectDialog';
 
 // TODO: This has become large and messy. Need to break it up into smaller components
@@ -89,7 +92,7 @@ function App() {
   // Variables for handling organizations
   const [organizations, setOrganizations] = useState<string[]>([]);
   const [selectedOrganization, setSelectedOrganization] = useState('');
-  const [projects, setProjects] = useState<string[]>([]);
+  const [projects, setProjects] = useState<Project[]>([]);
   const [selectedProject, setSelectedProject] = useState('');
   
   // Dialogs
@@ -150,10 +153,10 @@ function App() {
     if (timerRunning) {
       await stopTimer();
     }
-    const projs = await GetProjects(newOrganization);
-    SetOrganization(newOrganization, projs[0]).then(() => {
+    const projs: Project[] = await GetProjects(newOrganization);
+    SetOrganization(newOrganization, projs[0].Name).then(() => {
       setSelectedOrganization(newOrganization);
-      setSelectedProject(projs[0]);
+      setSelectedProject(projs[0].Name);
       setProjects(projs);
     });
   };
@@ -183,6 +186,16 @@ function App() {
     setOpenEditProj(true);
   };
 
+  const toggleFavoriteProject = (project: string) => {
+    ToggleFavoriteProject(selectedOrganization, project).then(() => {
+      const proj = projects.find(p => p.Name === project);
+      if (proj) {
+        proj.Favorite = !proj.Favorite;
+        setProjects([...projects]);
+      }
+    });
+  };
+
   const handleDeleteOrganization = async () => {
     ConfirmAction(`Delete ${selectedOrganization}`, "Are you sure you want to delete this organization?").then((confirmed) => {
       if (confirmed === false) {
@@ -199,7 +212,7 @@ function App() {
         setSelectedOrganization(newSelectedOrganization);
         GetProjects(newSelectedOrganization).then(projs => {
           setProjects(projs);
-          const newSelectedProject = projs[0];
+          const newSelectedProject = projs[0].Name;
           setSelectedProject(newSelectedProject);
           SetOrganization(newSelectedOrganization, newSelectedProject);
         });
@@ -218,8 +231,8 @@ function App() {
         return;
       }
       DeleteProject(selectedOrganization, project).then(() => {
-        setProjects(projs => projs.filter(proj => proj !== project));
-        const newSelectedProject = projects[0];
+        setProjects(projs => projs.filter(proj => proj.Name !== project));
+        const newSelectedProject = projects[0].Name;
         setSelectedProject(newSelectedProject);
         SetProject(newSelectedProject).then(() => {
           GetWorkTimeByProject(selectedOrganization, newSelectedProject, dateString())
@@ -243,8 +256,8 @@ function App() {
         setSelectedOrganization(orgs[0]);
         GetProjects(orgs[0]).then(projs => {
           setProjects(projs);
-          setSelectedProject(projs[0]);
-          SetOrganization(orgs[0], projs[0]);
+          setSelectedProject(projs[0].Name);
+          SetOrganization(orgs[0], projs[0].Name);
         });
       }
     });
@@ -261,11 +274,11 @@ function App() {
     GetProjects(selectedOrganization).then(projs => {
       setProjects(projs);
       // Handle case where the old project name matches the new project name for different organizations
-      if (projs[0] === selectedProject) {
-        GetWorkTimeByProject(selectedOrganization, projs[0], dateString())
+      if (projs[0].Name === selectedProject) {
+        GetWorkTimeByProject(selectedOrganization, projs[0].Name, dateString())
           .then(setCurrProjectWorkTime);
       }
-      setSelectedProject(projs[0]);
+      setSelectedProject(projs[0].Name);
     });
   }, [selectedOrganization]);
 
@@ -406,10 +419,20 @@ function App() {
             }}
             renderValue={(selected) => <div>{selected}</div>}
           >
-            {projects.map((project) => (
-              <MenuItem key={project} value={project} sx={{ display: 'flex', justifyContent: 'space-between' }}>
+            {projects.sort((a, b) => Number(b.Favorite) - Number(a.Favorite)).map((project, idx) => (
+              <MenuItem key={idx} value={project.Name} sx={{ display: 'flex', justifyContent: 'space-between' }}>
                 <div>
-                  {project}
+                  <IconButton
+                    edge="start"
+                    aria-label="favorite"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      toggleFavoriteProject(project.Name);
+                    }}
+                  >
+                    {project.Favorite ? <StarIcon /> : <StarBorderIcon />}
+                  </IconButton>
+                  {project.Name}
                 </div>
                 <div>
                   <Tooltip title="Edit project">
@@ -430,7 +453,7 @@ function App() {
                       aria-label="delete"
                       onClick={(event) => {
                         event.stopPropagation();
-                        handleDeleteProject(project);
+                        handleDeleteProject(project.Name);
                       }}
                     >
                       <DeleteIcon />
@@ -547,7 +570,7 @@ function App() {
         <WorkTimeAccordion
           timerRunning={timerRunning}
           selectedOrganization={selectedOrganization}
-          projects={projects}
+          projects={projects.map(proj => proj.Name)}
         />
       </div>
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -56,10 +56,11 @@ import {
   DeleteProject,
   ShowWindow,
   ConfirmAction,
+  ToggleFavoriteOrganization,
   ToggleFavoriteProject,
 } from "../wailsjs/go/main/App";
 
-import { getMonth, months, formatTime, dateString, getCurrentWeekOfMonth, Project } from './utils/utils'
+import { getMonth, months, formatTime, dateString, getCurrentWeekOfMonth, Model } from './utils/utils'
 import EditProjectDialog from './components/EditProjectDialog';
 
 // TODO: This has become large and messy. Need to break it up into smaller components
@@ -90,9 +91,9 @@ function App() {
   const currentDayRef = useRef(currentDay);
 
   // Variables for handling organizations
-  const [organizations, setOrganizations] = useState<string[]>([]);
+  const [organizations, setOrganizations] = useState<Model[]>([]);
   const [selectedOrganization, setSelectedOrganization] = useState('');
-  const [projects, setProjects] = useState<Project[]>([]);
+  const [projects, setProjects] = useState<Model[]>([]);
   const [selectedProject, setSelectedProject] = useState('');
   
   // Dialogs
@@ -153,10 +154,13 @@ function App() {
     if (timerRunning) {
       await stopTimer();
     }
-    const projs: Project[] = await GetProjects(newOrganization);
-    SetOrganization(newOrganization, projs[0].Name).then(() => {
+    const projs: Model[] = await GetProjects(newOrganization);
+    projs.sort(handleSort);
+    const project = projs[0].Name;
+
+    SetOrganization(newOrganization, project).then(() => {
       setSelectedOrganization(newOrganization);
-      setSelectedProject(projs[0].Name);
+      setSelectedProject(project);
       setProjects(projs);
     });
   };
@@ -186,6 +190,16 @@ function App() {
     setOpenEditProj(true);
   };
 
+  const toggleFavoriteOrg = (organization: string) => {
+    ToggleFavoriteOrganization(organization).then(() => {
+      const org = organizations.find(org => org.Name === organization);
+      if (org) {
+        org.Favorite = !org.Favorite;
+        setOrganizations([...organizations]);
+      }
+    });
+  };
+  
   const toggleFavoriteProject = (project: string) => {
     ToggleFavoriteProject(selectedOrganization, project).then(() => {
       const proj = projects.find(p => p.Name === project);
@@ -207,12 +221,13 @@ function App() {
         return;
       }
       DeleteOrganization(selectedOrganization).then(() => {
-        setOrganizations(orgs => orgs.filter(org => org !== selectedOrganization));
-        const newSelectedOrganization = organizations[0];
+        setOrganizations(orgs => orgs.filter(org => org.Name !== selectedOrganization));
+        const newSelectedOrganization = organizations.sort(handleSort)[0].Name;
         setSelectedOrganization(newSelectedOrganization);
+
         GetProjects(newSelectedOrganization).then(projs => {
           setProjects(projs);
-          const newSelectedProject = projs[0].Name;
+          const newSelectedProject = projs.sort(handleSort)[0].Name;
           setSelectedProject(newSelectedProject);
           SetOrganization(newSelectedOrganization, newSelectedProject);
         });
@@ -232,8 +247,9 @@ function App() {
       }
       DeleteProject(selectedOrganization, project).then(() => {
         setProjects(projs => projs.filter(proj => proj.Name !== project));
-        const newSelectedProject = projects[0].Name;
+        const newSelectedProject = projects.sort(handleSort)[0].Name;
         setSelectedProject(newSelectedProject);
+
         SetProject(newSelectedProject).then(() => {
           GetWorkTimeByProject(selectedOrganization, newSelectedProject, dateString())
             .then(setCurrProjectWorkTime);
@@ -242,22 +258,37 @@ function App() {
     });
   };
 
+  const handleSort = (a: Model, b: Model) => {
+    if (a.Favorite === b.Favorite) {
+    // If both projects have the same Favorite status, sort by UpdatedAt
+      return new Date(b.UpdatedAt).getTime() - new Date(a.UpdatedAt).getTime();
+    } else {
+      // Otherwise, sort by Favorite
+      return Number(b.Favorite) - Number(a.Favorite);
+    }
+  };
+
   /**
    * Get organizations defined in database when the app loads
    * If no organizations are defined, prompt the user to create one
    */
   useEffect(() => {
     getCurrentWeekOfMonth().then(setCurrentWeek);
-    GetOrganizations().then(orgs => {
+    GetOrganizations().then((orgs: Model[]) => {
       if (orgs.length === 0) {
         setOpenNewOrg(true);
       } else {
         setOrganizations(orgs);
-        setSelectedOrganization(orgs[0]);
-        GetProjects(orgs[0]).then(projs => {
+        orgs.sort(handleSort);
+        const organization = orgs[0].Name;
+        setSelectedOrganization(organization);
+
+        GetProjects(organization).then((projs: Model[]) => {
           setProjects(projs);
-          setSelectedProject(projs[0].Name);
-          SetOrganization(orgs[0], projs[0].Name);
+          projs.sort(handleSort);
+          const project = projs[0].Name;
+          setSelectedProject(project);
+          SetOrganization(organization, project);
         });
       }
     });
@@ -271,14 +302,16 @@ function App() {
     if (!selectedOrganization) return;
     console.debug("Getting work time for organization", selectedOrganization);
     GetWorkTime(dateString(), selectedOrganization).then(setWorkTime);
-    GetProjects(selectedOrganization).then(projs => {
+    GetProjects(selectedOrganization).then((projs: Model[]) => {
       setProjects(projs);
+      projs.sort(handleSort);
+      const project = projs[0].Name;
       // Handle case where the old project name matches the new project name for different organizations
-      if (projs[0].Name === selectedProject) {
-        GetWorkTimeByProject(selectedOrganization, projs[0].Name, dateString())
+      if (project === selectedProject) {
+        GetWorkTimeByProject(selectedOrganization, project, dateString())
           .then(setCurrProjectWorkTime);
       }
-      setSelectedProject(projs[0].Name);
+      setSelectedProject(project);
     });
   }, [selectedOrganization]);
 
@@ -401,10 +434,21 @@ function App() {
           <Select
             value={selectedOrganization}
             onChange={(event) => setOrganization(event.target.value as string)}
+            renderValue={(selected) => <div>{selected}</div>}
           >
-            {organizations.map((org) => (
-              <MenuItem key={org} value={org}>
-                {org}
+            {organizations.sort(handleSort).map((org, idx) => (
+              <MenuItem key={idx} value={org.Name}>
+                <IconButton
+                  edge="start"
+                  aria-label="favorite"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    toggleFavoriteOrg(org.Name);
+                  }}
+                >
+                  {org.Favorite ? <StarIcon /> : <StarBorderIcon />}
+                </IconButton>
+                {org.Name}
               </MenuItem>
             ))}
           </Select>
@@ -419,7 +463,7 @@ function App() {
             }}
             renderValue={(selected) => <div>{selected}</div>}
           >
-            {projects.sort((a, b) => Number(b.Favorite) - Number(a.Favorite)).map((project, idx) => (
+            {projects.sort(handleSort).map((project, idx) => (
               <MenuItem key={idx} value={project.Name} sx={{ display: 'flex', justifyContent: 'space-between' }}>
                 <div>
                   <IconButton

--- a/frontend/src/components/EditOrganizationDialog.tsx
+++ b/frontend/src/components/EditOrganizationDialog.tsx
@@ -5,16 +5,18 @@ import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField } 
 
 import { RenameOrganization, RenameProject } from '../../wailsjs/go/main/App';
 
+import { Project } from "../utils/utils";
+
 interface EditOrganizationDialogProps {
   openEditOrg: boolean;
   organization: string;
   organizations: string[];
   project: string;
-  projects: string[];
+  projects: Project[];
   setSelectedOrganization: (org: string) => void;
   setSelectedProject: (proj: string) => void;
   setOrganizations: React.Dispatch<React.SetStateAction<string[]>>;
-  setProjects: React.Dispatch<React.SetStateAction<string[]>>;
+  setProjects: React.Dispatch<React.SetStateAction<Project[]>>;
   setOpenEditOrg: (value: boolean) => void;
 }
 
@@ -43,9 +45,9 @@ const EditOrganizationDialog: React.FC<EditOrganizationDialogProps> = ({
       console.debug(`renaming project for ${organization} from ${project} to ${data.project}`);
       await RenameProject(organization, project, data.project);
       setProjects(prevProjects => {
-        const index = prevProjects.indexOf(project);
+        const index = prevProjects.findIndex((el) => el.Name === project);
         if (index > -1) {
-          prevProjects[index] = data.project;
+          prevProjects[index].Name = data.project;
           return [...prevProjects];
         }
         return prevProjects;
@@ -94,8 +96,8 @@ const EditOrganizationDialog: React.FC<EditOrganizationDialogProps> = ({
             label="New Project Name"
             type="text"
             fullWidth
-            error={projects.includes(newProj)}
-            helperText={projects.includes(newProj) ? 'Project name already exists' : ''}
+            error={projects.some((el) => el.Name === newProj)}
+            helperText={projects.some((el) => el.Name === newProj) ? 'Project name already exists' : ''}
             {...register("project")}
           />
         </DialogContent>
@@ -104,7 +106,7 @@ const EditOrganizationDialog: React.FC<EditOrganizationDialogProps> = ({
             type="submit"
             disabled={
               (!newOrg && !newProj)
-              || projects.includes(newProj)
+              || projects.some((el) => el.Name === newProj)
               || organizations.includes(newOrg)
             }>
             Save

--- a/frontend/src/components/EditOrganizationDialog.tsx
+++ b/frontend/src/components/EditOrganizationDialog.tsx
@@ -5,18 +5,18 @@ import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField } 
 
 import { RenameOrganization, RenameProject } from '../../wailsjs/go/main/App';
 
-import { Project } from "../utils/utils";
+import { Model } from "../utils/utils";
 
 interface EditOrganizationDialogProps {
   openEditOrg: boolean;
   organization: string;
-  organizations: string[];
+  organizations: Model[];
   project: string;
-  projects: Project[];
+  projects: Model[];
   setSelectedOrganization: (org: string) => void;
   setSelectedProject: (proj: string) => void;
-  setOrganizations: React.Dispatch<React.SetStateAction<string[]>>;
-  setProjects: React.Dispatch<React.SetStateAction<Project[]>>;
+  setOrganizations: React.Dispatch<React.SetStateAction<Model[]>>;
+  setProjects: React.Dispatch<React.SetStateAction<Model[]>>;
   setOpenEditOrg: (value: boolean) => void;
 }
 
@@ -57,9 +57,9 @@ const EditOrganizationDialog: React.FC<EditOrganizationDialogProps> = ({
     if (data.organization && data.organization !== organization) {
       await RenameOrganization(organization, data.organization);
       setOrganizations(prevOrgs => {
-        const index = prevOrgs.indexOf(organization);
+        const index = prevOrgs.findIndex((el) => el.Name === organization);
         if (index > -1) {
-          prevOrgs[index] = data.organization;
+          prevOrgs[index].Name = data.organization;
           return [...prevOrgs];
         }
         return prevOrgs;
@@ -85,8 +85,8 @@ const EditOrganizationDialog: React.FC<EditOrganizationDialogProps> = ({
             label="New Organization Name"
             type="text"
             fullWidth
-            error={organizations.includes(newOrg)}
-            helperText={organizations.includes(newOrg) ? 'Project name already exists' : ''}
+            error={organizations.some((el) => el.Name === newOrg)}
+            helperText={organizations.some((el) => el.Name === newOrg) ? 'Project name already exists' : ''}
             {...register("organization")}
           />
           <br />
@@ -107,7 +107,7 @@ const EditOrganizationDialog: React.FC<EditOrganizationDialogProps> = ({
             disabled={
               (!newOrg && !newProj)
               || projects.some((el) => el.Name === newProj)
-              || organizations.includes(newOrg)
+              || organizations.some((el) => el.Name === newOrg)
             }>
             Save
           </Button>

--- a/frontend/src/components/EditProjectDialog.tsx
+++ b/frontend/src/components/EditProjectDialog.tsx
@@ -5,15 +5,15 @@ import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField } 
 
 import { RenameProject } from '../../wailsjs/go/main/App';
 
-import { Project } from "../utils/utils";
+import { Model } from "../utils/utils";
 
 interface EditProjectDialogProps {
   openEditProj: boolean;
   organization: string;
   project: string;
-  projects: Project[];
+  projects: Model[];
   setSelectedProject: (proj: string) => void;
-  setProjects: React.Dispatch<React.SetStateAction<Project[]>>;
+  setProjects: React.Dispatch<React.SetStateAction<Model[]>>;
   setOpenEditProj: (value: boolean) => void;
 }
 

--- a/frontend/src/components/EditProjectDialog.tsx
+++ b/frontend/src/components/EditProjectDialog.tsx
@@ -5,13 +5,15 @@ import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField } 
 
 import { RenameProject } from '../../wailsjs/go/main/App';
 
+import { Project } from "../utils/utils";
+
 interface EditProjectDialogProps {
   openEditProj: boolean;
   organization: string;
   project: string;
-  projects: string[];
+  projects: Project[];
   setSelectedProject: (proj: string) => void;
-  setProjects: React.Dispatch<React.SetStateAction<string[]>>;
+  setProjects: React.Dispatch<React.SetStateAction<Project[]>>;
   setOpenEditProj: (value: boolean) => void;
 }
 
@@ -35,9 +37,9 @@ const EditProjectDialog: React.FC<EditProjectDialogProps> = ({
       console.debug(`renaming project for ${organization} from ${project} to ${data.project}`);
       await RenameProject(organization, project, data.project);
       setProjects(prevProjects => {
-        const index = prevProjects.indexOf(project);
+        const index = prevProjects.findIndex((el) => el.Name === project)
         if (index > -1) {
-          prevProjects[index] = data.project;
+          prevProjects[index].Name = data.project;
           return [...prevProjects];
         }
         return prevProjects;
@@ -62,15 +64,15 @@ const EditProjectDialog: React.FC<EditProjectDialogProps> = ({
             label="New Project Name"
             type="text"
             fullWidth
-            error={projects.includes(newProj)}
-            helperText={projects.includes(newProj) ? 'Project name already exists' : ''}
+            error={projects.some((el) => el.Name === newProj)}
+            helperText={projects.some((el) => el.Name === newProj) ? 'Project name already exists' : ''}
             {...register("project")}
           />
         </DialogContent>
         <DialogActions>
           <Button
             type="submit"
-            disabled={!newProj || projects.includes(newProj)}
+            disabled={!newProj || projects.some((el) => el.Name === newProj)}
           >
             Save
           </Button>

--- a/frontend/src/components/NewOrganizationDialog.tsx
+++ b/frontend/src/components/NewOrganizationDialog.tsx
@@ -1,15 +1,15 @@
 import { useForm, SubmitHandler } from "react-hook-form"
 import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, TextField } from '@mui/material';
 import { NewOrganization, SetOrganization } from '../../wailsjs/go/main/App';
-import { Project } from "../utils/utils";
+import { Model } from "../utils/utils";
 
 interface NewOrganizationDialogProps {
   openNewOrg: boolean;
-  organizations: string[];
+  organizations: Model[];
   setSelectedOrganization: (org: string) => void;
   setSelectedProject: (proj: string) => void;
-  setOrganizations: React.Dispatch<React.SetStateAction<string[]>>;
-  setProjects: React.Dispatch<React.SetStateAction<Project[]>>;
+  setOrganizations: React.Dispatch<React.SetStateAction<Model[]>>;
+  setProjects: React.Dispatch<React.SetStateAction<Model[]>>;
   setOpenNewOrg: (value: boolean) => void;
 }
 
@@ -34,8 +34,8 @@ const NewOrganizationDialog: React.FC<NewOrganizationDialogProps> = ({
     const { organization, project } = data;
     await NewOrganization(organization, project);
     await SetOrganization(organization, project);
-    setOrganizations(orgs => [...orgs, organization]);
-    setProjects(projs => [...projs, { Name: project, Favorite: false }]);
+    setOrganizations(orgs => [...orgs, { Name: organization, Favorite: false, UpdatedAt: new Date().toISOString() }]);
+    setProjects(projs => [...projs, { Name: project, Favorite: false, UpdatedAt: new Date().toISOString() }]);
     setSelectedOrganization(organization);
     setSelectedProject(project);
     setOpenNewOrg(false);
@@ -61,8 +61,8 @@ const NewOrganizationDialog: React.FC<NewOrganizationDialogProps> = ({
             label="Organization Name"
             type="text"
             fullWidth
-            error={organizations.includes(newOrg)}
-            helperText={organizations.includes(newOrg) ? 'Project name already exists' : ''}
+            error={organizations.some((el) => el.Name === newOrg)}
+            helperText={organizations.some((el) => el.Name === newOrg) ? 'Project name already exists' : ''}
             {...register("organization", { required: true })}
           />
           <br />
@@ -85,7 +85,7 @@ const NewOrganizationDialog: React.FC<NewOrganizationDialogProps> = ({
             disabled={
               !newOrg
               || !newProj
-              || organizations.includes(newOrg)
+              || organizations.some((el) => el.Name === newOrg)
             }>
             Confirm
           </Button>

--- a/frontend/src/components/NewOrganizationDialog.tsx
+++ b/frontend/src/components/NewOrganizationDialog.tsx
@@ -1,6 +1,7 @@
 import { useForm, SubmitHandler } from "react-hook-form"
 import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, TextField } from '@mui/material';
 import { NewOrganization, SetOrganization } from '../../wailsjs/go/main/App';
+import { Project } from "../utils/utils";
 
 interface NewOrganizationDialogProps {
   openNewOrg: boolean;
@@ -8,7 +9,7 @@ interface NewOrganizationDialogProps {
   setSelectedOrganization: (org: string) => void;
   setSelectedProject: (proj: string) => void;
   setOrganizations: React.Dispatch<React.SetStateAction<string[]>>;
-  setProjects: React.Dispatch<React.SetStateAction<string[]>>;
+  setProjects: React.Dispatch<React.SetStateAction<Project[]>>;
   setOpenNewOrg: (value: boolean) => void;
 }
 
@@ -34,7 +35,7 @@ const NewOrganizationDialog: React.FC<NewOrganizationDialogProps> = ({
     await NewOrganization(organization, project);
     await SetOrganization(organization, project);
     setOrganizations(orgs => [...orgs, organization]);
-    setProjects(projs => [...projs, project]);
+    setProjects(projs => [...projs, { Name: project, Favorite: false }]);
     setSelectedOrganization(organization);
     setSelectedProject(project);
     setOpenNewOrg(false);

--- a/frontend/src/components/NewProjectDialog.tsx
+++ b/frontend/src/components/NewProjectDialog.tsx
@@ -9,14 +9,14 @@ import {
   TextField
 } from '@mui/material';
 import { NewProject, SetProject } from '../../wailsjs/go/main/App';
-import { getMonth } from "../utils/utils";
+import { getMonth, Project } from "../utils/utils";
 
 interface NewProjectDialogProps {
   openNewProj: boolean;
   organization: string;
-  projects: string[];
+  projects: Project[];
   setSelectedProject: (proj: string) => void;
-  setProjects: React.Dispatch<React.SetStateAction<string[]>>;
+  setProjects: React.Dispatch<React.SetStateAction<Project[]>>;
   setMonthlyWorkTimes: React.Dispatch<React.SetStateAction<Record<number, Record<string, number>>>>;
   setOpenNewProj: (value: boolean) => void;
 }
@@ -40,7 +40,7 @@ const NewProjectDialog: React.FC<NewProjectDialogProps> = ({
     const { project } = data;
     await NewProject(organization, project);
     await SetProject(project);
-    setProjects(projs => [...projs, project]);
+    setProjects(projs => [...projs, { Name: project, Favorite: false }]);
     setSelectedProject(project);
     setMonthlyWorkTimes(prev => {
       prev[getMonth()][project] = 0;
@@ -68,15 +68,15 @@ const NewProjectDialog: React.FC<NewProjectDialogProps> = ({
             label="Project Name"
             type="text"
             fullWidth
-            error={projects.includes(newProj)}
-            helperText={projects.includes(newProj) ? 'Project name already exists' : ''}
+            error={projects.some((el) => el.Name === newProj)}
+            helperText={projects.some((el) => el.Name === newProj) ? 'Project name already exists' : ''}
             {...register("project", { required: true })}
           />
         </DialogContent>
         <DialogActions>
           <Button
             type="submit"
-            disabled={!newProj || projects.includes(newProj)}
+            disabled={!newProj || projects.some((el) => el.Name === newProj)}
           >
             Confirm
           </Button>

--- a/frontend/src/components/NewProjectDialog.tsx
+++ b/frontend/src/components/NewProjectDialog.tsx
@@ -9,14 +9,14 @@ import {
   TextField
 } from '@mui/material';
 import { NewProject, SetProject } from '../../wailsjs/go/main/App';
-import { getMonth, Project } from "../utils/utils";
+import { getMonth, Model } from "../utils/utils";
 
 interface NewProjectDialogProps {
   openNewProj: boolean;
   organization: string;
-  projects: Project[];
+  projects: Model[];
   setSelectedProject: (proj: string) => void;
-  setProjects: React.Dispatch<React.SetStateAction<Project[]>>;
+  setProjects: React.Dispatch<React.SetStateAction<Model[]>>;
   setMonthlyWorkTimes: React.Dispatch<React.SetStateAction<Record<number, Record<string, number>>>>;
   setOpenNewProj: (value: boolean) => void;
 }
@@ -40,7 +40,7 @@ const NewProjectDialog: React.FC<NewProjectDialogProps> = ({
     const { project } = data;
     await NewProject(organization, project);
     await SetProject(project);
-    setProjects(projs => [...projs, { Name: project, Favorite: false }]);
+    setProjects(projs => [...projs, { Name: project, Favorite: false, UpdatedAt: new Date().toISOString() }]);
     setSelectedProject(project);
     setMonthlyWorkTimes(prev => {
       prev[getMonth()][project] = 0;

--- a/frontend/src/utils/utils.tsx
+++ b/frontend/src/utils/utils.tsx
@@ -49,3 +49,8 @@ export async function getCurrentWeekOfMonth() {
   const week = await GetWeekOfMonth(year, month, day);
   return week
 };
+
+export type Project = {
+  Name: string;
+  Favorite: boolean;
+};

--- a/frontend/src/utils/utils.tsx
+++ b/frontend/src/utils/utils.tsx
@@ -50,7 +50,8 @@ export async function getCurrentWeekOfMonth() {
   return week
 };
 
-export type Project = {
+export type Model = {
   Name: string;
   Favorite: boolean;
+  UpdatedAt: string;
 };

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -15,7 +15,7 @@ export function ExportByYear(arg1:main.ExportType,arg2:string,arg3:number):Promi
 
 export function GetMonthlyWorkTime(arg1:number,arg2:string):Promise<{[key: number]: {[key: string]: number}}>;
 
-export function GetOrganizations():Promise<Array<string>>;
+export function GetOrganizations():Promise<Array<main.Organization>>;
 
 export function GetProjects(arg1:string):Promise<Array<main.Project>>;
 

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -17,7 +17,7 @@ export function GetMonthlyWorkTime(arg1:number,arg2:string):Promise<{[key: numbe
 
 export function GetOrganizations():Promise<Array<string>>;
 
-export function GetProjects(arg1:string):Promise<Array<string>>;
+export function GetProjects(arg1:string):Promise<Array<main.Project>>;
 
 export function GetVersion():Promise<string>;
 
@@ -52,5 +52,9 @@ export function StartTimer(arg1:string,arg2:string):Promise<void>;
 export function StopTimer(arg1:string,arg2:string):Promise<void>;
 
 export function TimeElapsed():Promise<number>;
+
+export function ToggleFavoriteOrganization(arg1:string):Promise<void>;
+
+export function ToggleFavoriteProject(arg1:string,arg2:string):Promise<void>;
 
 export function UpdateAvailable():Promise<boolean>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -102,6 +102,14 @@ export function TimeElapsed() {
   return window['go']['main']['App']['TimeElapsed']();
 }
 
+export function ToggleFavoriteOrganization(arg1) {
+  return window['go']['main']['App']['ToggleFavoriteOrganization'](arg1);
+}
+
+export function ToggleFavoriteProject(arg1, arg2) {
+  return window['go']['main']['App']['ToggleFavoriteProject'](arg1, arg2);
+}
+
 export function UpdateAvailable() {
   return window['go']['main']['App']['UpdateAvailable']();
 }


### PR DESCRIPTION
### Description:
Implement a way to favorite organizations and projects so they appear at the top of their respective dropdowns.

### 🧠 Rationale behind the change
Adding a way to set which organizations or projects appear at the top of the list is helpful if the user has a lot of projects/organizations to choose from or wants to have a specific project/organization be loaded on startup

### Commits & Changes:
- backend
  - Added `Favorite` column to the `Organizations` and `Projects` table
  - Added `ToggleFavoriteOrganization` and `ToggleFavoriteProject` methods
  - Changed `GetOrganizations` and `GetProjects` to return array of the respective structs
- frontend
  - Added `StarIcon` to both organizations and projects dropdowns, with IconButton for on
  - Create `toggleFavoriteProject` and `toggleFavoriteOrg`
  - Added `handleSort` method that sorts first by `Favorite` status then by `UpdatedAt` date
  - Created new `Model` type in utils. Model type is our basics from both the Organization and Project structs, (Name, Favorite, UpdatedAt)

### 📸 Screenshots (optional)
![image](https://github.com/theBGuy/go-work-tracker/assets/60308670/20fc9a69-5664-4adf-a9da-4e0e65158825)
![image](https://github.com/theBGuy/go-work-tracker/assets/60308670/df11e647-e77a-4a79-ab34-8ad73ea9e6a6)

### 🏎 Quality check

- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?

- [x] Walk away, take a break, re-read what you filled out above does it make sense if you were coming in cold? What extra context could you provide?