### PR TITLE
[BugFix] Ignoring processes during wails build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,7 @@ jobs:
         env:
           APP_ENV: production
           APP_VERSION: ${{ env.version }}
+          BUILDING: "true"
       - name: Upload build artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/helpers.go
+++ b/helpers.go
@@ -73,6 +73,9 @@ func containsAll(str string, keys []string) bool {
 // and the database is now managed by GORM in version 0.5.0
 // normalized database in 0.6.0 so handle transition from old single table to new normalized tables
 func fixOutdatedDb(db *gorm.DB) {
+	if os.Getenv("BUILDING") == "true" {
+		return
+	}
 	// Query the sqlite_master table to get the SQL used to create the work_hours table
 	row := db.Raw("SELECT sql FROM sqlite_master WHERE type='table' AND name='work_hours'").Row()
 	var createSQL string


### PR DESCRIPTION
### Description:
Wails for some reason runs the code when generating the bindings so need to ignore some processes. Add a environment variable to the gh action workflow so we know it's in the process of building and not to perform runtime actions

### Commits & Changes:
- `workflows/main.yml`
  - Added `BUILDING="true"

### 🏎 Quality check

- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?

- [x] Walk away, take a break, re-read what you filled out above does it make sense if you were coming in cold? What extra context could you provide?