### PR TITLE
[Minor][Feat] Add a go-routine to cleanup records that were deleted 30+ days ago

### DIFF
--- a/app.go
+++ b/app.go
@@ -103,6 +103,7 @@ func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
 	a.monitorTime()
 	a.monitorUpdates()
+	a.cleanupRoutine()
 }
 
 // shutdown is called at termination
@@ -146,6 +147,18 @@ func (a *App) monitorUpdates() {
 					runtime.EventsEmit(a.ctx, "update-available")
 				}
 			}
+		}
+	}()
+}
+
+func (a *App) cleanupRoutine() {
+	// Run on startup then every 24 hours
+	a.cleanupSoftDeletedRecords()
+	ticker := time.NewTicker(24 * time.Hour)
+
+	go func() {
+		for range ticker.C {
+			a.cleanupSoftDeletedRecords()
 		}
 	}()
 }

--- a/db.go
+++ b/db.go
@@ -54,6 +54,34 @@ func handleDBError(err error) {
 	}
 }
 
+func (a *App) cleanupSoftDeletedRecords() {
+	query := "deleted_at IS NOT NULL AND deleted_at <= datetime('now', '-30 days')"
+
+	// Delete soft deleted records for WorkHours
+	result := a.db.Unscoped().Where(query).Delete(&WorkHours{})
+	if err := result.Error; err != nil {
+		log.Printf("Error deleting WorkHours records: %v", err)
+	} else {
+		log.Printf("Deleted %d WorkHours records", result.RowsAffected)
+	}
+
+	// Delete soft deleted records for Project
+	result = a.db.Unscoped().Where(query).Delete(&Project{})
+	if err := result.Error; err != nil {
+		log.Printf("Error deleting Project records: %v", err)
+	} else {
+		log.Printf("Deleted %d Project records", result.RowsAffected)
+	}
+
+	// Delete soft deleted records for Organization
+	result = a.db.Unscoped().Where(query).Delete(&Organization{})
+	if err := result.Error; err != nil {
+		log.Printf("Error deleting Organization records: %v", err)
+	} else {
+		log.Printf("Deleted %d Organization records", result.RowsAffected)
+	}
+}
+
 func NewDb(dbDir string) *gorm.DB {
 	db, err := gorm.Open(sqlite.Open(filepath.Join(dbDir, "worktracker.sqlite")), &gorm.Config{})
 	handleDBError(err)

--- a/main.go
+++ b/main.go
@@ -18,10 +18,14 @@ var WailsConfigFile []byte
 func main() {
 	// Create an instance of the app structure
 	app := NewApp()
+	appTitle := "Go Work Tracker"
+	if app.environment == "development" {
+		appTitle = appTitle + " (DEV)"
+	}
 
 	// Create application with options
 	err := wails.Run(&options.App{
-		Title:  "go-work-tracker",
+		Title:  appTitle,
 		Width:  1024,
 		Height: 768,
 		AssetServer: &assetserver.Options{

--- a/wails.json
+++ b/wails.json
@@ -14,7 +14,7 @@
     "productName": "go-work-tracker",
     "description": "A simple work tracker written in Go and Wails",
     "license": "MIT",
-    "productVersion": "0.7.1",
+    "productVersion": "0.8.0",
     "environment": "development"
   }
 }


### PR DESCRIPTION
### Description:
This PR adds a routine that will run once on startup then again every 24hours to cleanup records that were soft-deleted 30+ days ago.

### 🧠 Rationale behind the change
Using soft-delete is good because it gives users the ability to restore information but after a certain amount of time it makes sense to clean up old records 

### Commits & Changes:
- `app.go`
  - Added `cleanupRoutine` that starts a go-routine that calls `cleanupSoftDeletedRecords` every 24hours
- `db.go`
  - Added `cleanupSoftDeletedRecords` which handles checking each of our tables for records that were soft deleted 30 days ago

### 🏎 Quality check

- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?

- [x] Walk away, take a break, re-read what you filled out above does it make sense if you were coming in cold? What extra context could you provide?