### PR TITLE
[Patch][Hotfix] Chart y-axis formatting

### DIFF
--- a/frontend/src/routes/Charts.tsx
+++ b/frontend/src/routes/Charts.tsx
@@ -154,9 +154,14 @@ function Charts() {
       <Stack spacing={1} sx={{ padding: 2 }}>
         <Paper sx={{ padding: 2 }}>
           <Stack direction="row" spacing={2}>
-            <FormControl fullWidth margin="normal">
-              <InputLabel>Year</InputLabel>
-              <Select value={selectedYear} onChange={(event) => setSelectedYear(event.target.value as number)}>
+            <FormControl fullWidth>
+              <InputLabel id="year-label">Year</InputLabel>
+              <Select
+                value={selectedYear}
+                label="Year"
+                labelId="year-label"
+                onChange={(event) => setSelectedYear(event.target.value as number)}
+              >
                 {years.map((year) => (
                   <MenuItem key={year} value={year}>
                     {year}
@@ -166,7 +171,11 @@ function Charts() {
             </FormControl>
             <FormControl fullWidth margin="normal">
               <InputLabel>Month</InputLabel>
-              <Select value={selectedMonth} onChange={(event) => setSelectedMonth(event.target.value as number)}>
+              <Select
+                value={selectedMonth}
+                label="Month"
+                onChange={(event) => setSelectedMonth(event.target.value as number)}
+              >
                 {Object.entries(months).map(([monthNumber, monthName]) => (
                   <MenuItem key={Number(monthNumber)} value={Number(monthNumber)}>
                     {monthName}
@@ -178,6 +187,7 @@ function Charts() {
               <InputLabel>Organization</InputLabel>
               <Select
                 value={selectedOrganization?.name}
+                label="Organization"
                 onChange={(event) => {
                   const foundOrg = organizations.find((org) => org.name === event.target.value);
                   if (foundOrg) {

--- a/wails.json
+++ b/wails.json
@@ -14,7 +14,7 @@
     "productName": "go-work-tracker",
     "description": "A simple work tracker written in Go and Wails",
     "license": "MIT",
-    "productVersion": "0.8.0",
+    "productVersion": "0.9.3",
     "environment": "development"
   }
 }


### PR DESCRIPTION
### Description:
This PR fixes the double printing of the axis ticks introduced in #29 

### Commits & Changes:
- `Charts.tsx`
  - Fixed `valueFormatter` method on the YAxisConfig object

### 📸 Screenshots (optional)

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/864c23ed-626a-4221-9a05-9291a00efe38) | ![image](https://github.com/user-attachments/assets/5ada1757-d4a6-4bca-b6b7-136529d23f0a) |

### 🏎 Quality check

- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?

- [x] Walk away, take a break, re-read what you filled out above does it make sense if you were coming in cold? What extra context could you provide?