### PR TITLE
[Patch][Hotfix] Add back interval to watch for new day

### DIFF
--- a/frontend/src/stores/main.ts
+++ b/frontend/src/stores/main.ts
@@ -1,3 +1,4 @@
+import { dateString } from "@/utils/utils";
 import { main } from "@go/models";
 import { create } from "zustand";
 import { createJSONStorage, persist, subscribeWithSelector } from "zustand/middleware";
@@ -35,6 +36,8 @@ interface Store {
   orgMonthTotal: number;
   setOrgMonthTotal: (value: number) => void;
   updateOrgMonthTotal: (value: number) => void;
+  dateStr: string;
+  setDateStr: (date: string) => void;
   currentWeek: number;
   setCurrentWeek: (week: number) => void;
   projWeekTotal: number;
@@ -142,6 +145,11 @@ export const useAppStore = create(
         set({ orgMonthTotal: value });
       },
       updateOrgMonthTotal: (value: number) => set((state) => ({ orgMonthTotal: state.orgMonthTotal + value })),
+      dateStr: dateString(),
+      setDateStr: (date: string) => {
+        if (date === get().dateStr) return;
+        set({ dateStr: date });
+      },
       currentWeek: 1,
       setCurrentWeek: (week: number) => {
         if (week === get().currentWeek) return;

--- a/frontend/src/utils/utils.tsx
+++ b/frontend/src/utils/utils.tsx
@@ -33,8 +33,7 @@ export const getMonth = (d = new Date()): number => {
   return d.getMonth() + 1;
 };
 
-export const dateString = () => {
-  const date = new Date();
+export const dateString = (date = new Date()) => {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0");
   const day = String(date.getDate()).padStart(2, "0");


### PR DESCRIPTION
### Description:
This PR adds back an interval removed in #25 to watch for a date change so we can display the correct information to the user. It implements a zustand subscription to the dateStr state so we can then respond to the change in date

### 🧠 Rationale behind the change
It makes sense to add back this interval to the JS side instead of modifying the go-routine that currently checks day while the timer is running. JS's event loop is better suited for this task.

### Commits & Changes:
- `App.tsx`
  - Added `dateStr` subscription to respond to new day events
  - Added interval to watch check for new day based on dateString

### 🏎 Quality check

- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?

- [ ] Walk away, take a break, re-read what you filled out above does it make sense if you were coming in cold? What extra context could you provide?