### PR TITLE
[Minor][Feat] Miniature timer

### DIFF
--- a/app.go
+++ b/app.go
@@ -273,16 +273,16 @@ var minOrgX, minOrgY int
 
 func (a *App) NormalizeWindow() {
 	runtime.WindowSetMaxSize(a.ctx, 0, 0)
-	runtime.WindowSetMinSize(a.ctx, 0, 0)
 	runtime.WindowCenter(a.ctx)
 	runtime.WindowSetSize(a.ctx, WIN_WIDTH, WIN_HEIGHT)
+	runtime.WindowSetMinSize(a.ctx, MIN_WIN_WIDTH, MIN_WIN_HEIGHT)
 	runtime.WindowCenter(a.ctx)
 	runtime.WindowSetAlwaysOnTop(a.ctx, false)
 }
 
 func (a *App) MinimizeWindow() {
+	runtime.WindowSetMinSize(a.ctx, WIDGET_WIDTH, WIDGET_HEIGHT)
 	runtime.WindowSetSize(a.ctx, WIDGET_WIDTH, WIDGET_HEIGHT)
 	runtime.WindowSetMaxSize(a.ctx, WIDGET_WIDTH, WIDGET_HEIGHT)
-	runtime.WindowSetMinSize(a.ctx, WIDGET_WIDTH, WIDGET_HEIGHT)
 	runtime.WindowSetAlwaysOnTop(a.ctx, true)
 }

--- a/app.go
+++ b/app.go
@@ -272,30 +272,17 @@ var minOrgX, minOrgY int
 // }
 
 func (a *App) NormalizeWindow() {
-	// minOrgX, minOrgY = runtime.WindowGetPosition(a.ctx)
 	runtime.WindowSetMaxSize(a.ctx, 0, 0)
 	runtime.WindowSetMinSize(a.ctx, 0, 0)
 	runtime.WindowCenter(a.ctx)
-	// if normalOrgX != 0 && normalOrgY != 0 {
-	// 	runtime.WindowSetPosition(a.ctx, normalOrgX, normalOrgY)
-	// }
 	runtime.WindowSetSize(a.ctx, WIN_WIDTH, WIN_HEIGHT)
+	runtime.WindowCenter(a.ctx)
 	runtime.WindowSetAlwaysOnTop(a.ctx, false)
 }
 
 func (a *App) MinimizeWindow() {
-	// winDim, err := getScreenSize()
-	// if err != nil {
-	// 	return
-	// }
-	// fmt.Println("Screen size: ", winDim)
-	// normalOrgX, normalOrgY = runtime.WindowGetPosition(a.ctx)
 	runtime.WindowSetSize(a.ctx, WIDGET_WIDTH, WIDGET_HEIGHT)
 	runtime.WindowSetMaxSize(a.ctx, WIDGET_WIDTH, WIDGET_HEIGHT)
 	runtime.WindowSetMinSize(a.ctx, WIDGET_WIDTH, WIDGET_HEIGHT)
-	// How do I get the position of the bottom right corner of the screen?
-	// if minOrgX != 0 && minOrgY != 0 {
-	// 	runtime.WindowSetPosition(a.ctx, minOrgX, minOrgY)
-	// }
 	runtime.WindowSetAlwaysOnTop(a.ctx, true)
 }

--- a/app.go
+++ b/app.go
@@ -242,25 +242,60 @@ func (a *App) ConfirmAction(title string, message string) bool {
 var normalOrgX, normalOrgY int
 var minOrgX, minOrgY int
 
+// type WindowSize struct {
+// 	Width  int `json:"width"`
+// 	Height int `json:"height"`
+// }
+
+// func getScreenSize() (WindowSize, error) {
+// 	if err := glfw.Init(); err != nil {
+// 		fmt.Println("failed to initialize glfw:", err)
+// 		return WindowSize{}, err
+// 	}
+// 	defer glfw.Terminate()
+
+// 	// Get the primary monitor
+// 	monitor := glfw.GetPrimaryMonitor()
+// 	if monitor == nil {
+// 		fmt.Println("failed to get primary monitor")
+// 		return WindowSize{}, errors.New("failed to get primary monitor")
+// 	}
+
+// 	// Get the video mode of the primary monitor
+// 	mode := monitor.GetVideoMode()
+// 	if mode == nil {
+// 		fmt.Println("failed to get video mode")
+// 		return WindowSize{}, errors.New("failed to get video mode")
+// 	}
+
+// 	return WindowSize{Width: mode.Width, Height: mode.Height}, nil
+// }
+
 func (a *App) NormalizeWindow() {
-	minOrgX, minOrgY = runtime.WindowGetPosition(a.ctx)
+	// minOrgX, minOrgY = runtime.WindowGetPosition(a.ctx)
 	runtime.WindowSetMaxSize(a.ctx, 0, 0)
 	runtime.WindowSetMinSize(a.ctx, 0, 0)
-	if normalOrgX != 0 && normalOrgY != 0 {
-		runtime.WindowSetPosition(a.ctx, normalOrgX, normalOrgY)
-	}
+	runtime.WindowCenter(a.ctx)
+	// if normalOrgX != 0 && normalOrgY != 0 {
+	// 	runtime.WindowSetPosition(a.ctx, normalOrgX, normalOrgY)
+	// }
 	runtime.WindowSetSize(a.ctx, WIN_WIDTH, WIN_HEIGHT)
 	runtime.WindowSetAlwaysOnTop(a.ctx, false)
 }
 
 func (a *App) MinimizeWindow() {
-	normalOrgX, normalOrgY = runtime.WindowGetPosition(a.ctx)
+	// winDim, err := getScreenSize()
+	// if err != nil {
+	// 	return
+	// }
+	// fmt.Println("Screen size: ", winDim)
+	// normalOrgX, normalOrgY = runtime.WindowGetPosition(a.ctx)
 	runtime.WindowSetSize(a.ctx, WIDGET_WIDTH, WIDGET_HEIGHT)
 	runtime.WindowSetMaxSize(a.ctx, WIDGET_WIDTH, WIDGET_HEIGHT)
 	runtime.WindowSetMinSize(a.ctx, WIDGET_WIDTH, WIDGET_HEIGHT)
 	// How do I get the position of the bottom right corner of the screen?
-	if minOrgX != 0 && minOrgY != 0 {
-		runtime.WindowSetPosition(a.ctx, minOrgX, minOrgY)
-	}
+	// if minOrgX != 0 && minOrgY != 0 {
+	// 	runtime.WindowSetPosition(a.ctx, minOrgX, minOrgY)
+	// }
 	runtime.WindowSetAlwaysOnTop(a.ctx, true)
 }

--- a/app.go
+++ b/app.go
@@ -238,3 +238,29 @@ func (a *App) ConfirmAction(title string, message string) bool {
 	}
 	return selection == "Yes"
 }
+
+var normalOrgX, normalOrgY int
+var minOrgX, minOrgY int
+
+func (a *App) NormalizeWindow() {
+	minOrgX, minOrgY = runtime.WindowGetPosition(a.ctx)
+	runtime.WindowSetMaxSize(a.ctx, 0, 0)
+	runtime.WindowSetMinSize(a.ctx, 0, 0)
+	if normalOrgX != 0 && normalOrgY != 0 {
+		runtime.WindowSetPosition(a.ctx, normalOrgX, normalOrgY)
+	}
+	runtime.WindowSetSize(a.ctx, WIN_WIDTH, WIN_HEIGHT)
+	runtime.WindowSetAlwaysOnTop(a.ctx, false)
+}
+
+func (a *App) MinimizeWindow() {
+	normalOrgX, normalOrgY = runtime.WindowGetPosition(a.ctx)
+	runtime.WindowSetSize(a.ctx, WIDGET_WIDTH, WIDGET_HEIGHT)
+	runtime.WindowSetMaxSize(a.ctx, WIDGET_WIDTH, WIDGET_HEIGHT)
+	runtime.WindowSetMinSize(a.ctx, WIDGET_WIDTH, WIDGET_HEIGHT)
+	// How do I get the position of the bottom right corner of the screen?
+	if minOrgX != 0 && minOrgY != 0 {
+		runtime.WindowSetPosition(a.ctx, minOrgX, minOrgY)
+	}
+	runtime.WindowSetAlwaysOnTop(a.ctx, true)
+}

--- a/frontend/src/components/ActiveConfirmationDialog.tsx
+++ b/frontend/src/components/ActiveConfirmationDialog.tsx
@@ -1,7 +1,7 @@
 import { useAppStore } from "@/stores/main";
 import { MinimizeWindow, NormalizeWindow } from "@go/main/App";
 import { Button, Dialog, DialogActions, DialogTitle } from "@mui/material";
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useTimerStore } from "../stores/timer";
 
 const ActiveConfirmationDialog: React.FC = () => {
@@ -9,21 +9,23 @@ const ActiveConfirmationDialog: React.FC = () => {
   const timerRunning = useTimerStore((state) => state.running);
   const stopTimer = useTimerStore((state) => state.stopTimer);
   const [openConfirm, setOpenConfirm] = useTimerStore((state) => [state.openConfirm, state.setOpenConfirm]);
+  const [wasMinimized, setWasMinimized] = useState(false);
   const handleClose = async () => {
     setOpenConfirm(false);
-    if (useAppStore.getState().appMode === "widget") {
+    if (wasMinimized) {
+      setAppMode("widget");
+      setWasMinimized(false);
       await MinimizeWindow();
     }
   };
 
   const handleStop = async (timedOut: boolean) => {
     stopTimer();
-    if (useAppStore.getState().appMode === "widget") {
+    if (wasMinimized) {
+      setWasMinimized(false);
       if (timedOut) {
         setAppMode("normal"); // User is away so when they come back, they should see the app
         await NormalizeWindow();
-      } else {
-        await MinimizeWindow();
       }
     }
   };
@@ -32,11 +34,13 @@ const ActiveConfirmationDialog: React.FC = () => {
     // TODO: maybe some sort of sound alert? or a notification? In case the user is not looking at the app
     if (openConfirm) {
       if (useAppStore.getState().appMode === "widget") {
+        setWasMinimized(true);
+        setAppMode("normal");
         NormalizeWindow();
       }
-      const timeout = setTimeout(() => {
+      const timeout = setTimeout(async () => {
         if (timerRunning) {
-          handleStop(true);
+          await handleStop(true);
           alert("You didn't confirm within two minutes. The timer will be stopped.");
         }
       }, 1000 * 60 * 2);

--- a/frontend/src/components/ActiveConfirmationDialog.tsx
+++ b/frontend/src/components/ActiveConfirmationDialog.tsx
@@ -1,18 +1,42 @@
+import { useAppStore } from "@/stores/main";
+import { MinimizeWindow, NormalizeWindow } from "@go/main/App";
+import { Button, Dialog, DialogActions, DialogTitle } from "@mui/material";
 import React, { useEffect } from "react";
-import { Dialog, DialogTitle, DialogActions, Button } from "@mui/material";
 import { useTimerStore } from "../stores/timer";
 
 const ActiveConfirmationDialog: React.FC = () => {
+  const setAppMode = useAppStore((state) => state.setAppMode);
   const timerRunning = useTimerStore((state) => state.running);
   const stopTimer = useTimerStore((state) => state.stopTimer);
   const [openConfirm, setOpenConfirm] = useTimerStore((state) => [state.openConfirm, state.setOpenConfirm]);
+  const handleClose = async () => {
+    setOpenConfirm(false);
+    if (useAppStore.getState().appMode === "widget") {
+      await MinimizeWindow();
+    }
+  };
+
+  const handleStop = async (timedOut: boolean) => {
+    stopTimer();
+    if (useAppStore.getState().appMode === "widget") {
+      if (timedOut) {
+        setAppMode("normal"); // User is away so when they come back, they should see the app
+        await NormalizeWindow();
+      } else {
+        await MinimizeWindow();
+      }
+    }
+  };
 
   useEffect(() => {
     // TODO: maybe some sort of sound alert? or a notification? In case the user is not looking at the app
     if (openConfirm) {
+      if (useAppStore.getState().appMode === "widget") {
+        NormalizeWindow();
+      }
       const timeout = setTimeout(() => {
         if (timerRunning) {
-          stopTimer();
+          handleStop(true);
           alert("You didn't confirm within two minutes. The timer will be stopped.");
         }
       }, 1000 * 60 * 2);
@@ -21,11 +45,11 @@ const ActiveConfirmationDialog: React.FC = () => {
   }, [openConfirm]);
 
   return (
-    <Dialog disableEscapeKeyDown open={openConfirm} onClose={() => setOpenConfirm(false)}>
+    <Dialog disableEscapeKeyDown open={openConfirm} onClose={handleClose}>
       <DialogTitle>Are you still working?</DialogTitle>
       <DialogActions>
-        <Button onClick={() => setOpenConfirm(false)}>Yes</Button>
-        <Button onClick={() => stopTimer()}>No</Button>
+        <Button onClick={handleClose}>Yes</Button>
+        <Button onClick={() => handleStop(false)}>No</Button>
       </DialogActions>
     </Dialog>
   );

--- a/frontend/src/components/ActiveSession.tsx
+++ b/frontend/src/components/ActiveSession.tsx
@@ -1,9 +1,23 @@
-import { Card, CardContent, CardHeader, Typography, CardActions, Button, Box, IconButton, Stack } from "@mui/material";
-import { formatTime } from "../utils/utils";
-import { useTimerStore } from "../stores/timer";
+import { MinimizeWindow, NormalizeWindow } from "@go/main/App";
+import OpenInFull from "@mui/icons-material/OpenInFull";
+import OpenInNew from "@mui/icons-material/OpenInNew";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import StopIcon from "@mui/icons-material/Stop";
+import {
+  Box,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  CardHeader,
+  IconButton,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
 import { useAppStore } from "../stores/main";
+import { useTimerStore } from "../stores/timer";
+import { formatTime } from "../utils/utils";
 
 interface activeSessionProps {
   stopTimer: () => void;
@@ -16,54 +30,105 @@ const ActiveSession: React.FC<activeSessionProps> = ({ stopTimer, mode = "normal
   const timerRunning = useTimerStore((state) => state.running);
   const org = useAppStore((state) => state.activeOrg);
   const proj = useAppStore((state) => state.activeProj);
+  const appMode = useAppStore((state) => state.appMode);
+  const setAppMode = useAppStore((state) => state.setAppMode);
+
+  const minimize = async () => {
+    setAppMode("widget");
+    await MinimizeWindow();
+  };
+
+  const maximize = async () => {
+    setAppMode("normal");
+    await NormalizeWindow();
+  };
 
   return (
     <>
-      {mode === "normal" ? (
-        <div style={{ display: "flex", justifyContent: "center", alignItems: "center" }}>
-          <Card sx={{ display: "inline-block", transform: "scale(0.9)" }}>
-            <CardContent>
-              <CardHeader title="Current Work Session" />
-              <Typography variant="h5" component="h2">
-                {timerRunning ? formatTime(elapsedTime) : "00h 00m 00s"}
+      {appMode === "normal" &&
+        (mode === "normal" ? (
+          <div style={{ display: "flex", justifyContent: "center", alignItems: "center" }}>
+            <Card sx={{ display: "inline-block", transform: "scale(0.9)" }}>
+              <Tooltip title="Open in widget mode" placement="right">
+                <IconButton sx={{ position: "absolute", top: -5, right: -5 }} onClick={minimize}>
+                  <OpenInNew />
+                </IconButton>
+              </Tooltip>
+              <CardContent>
+                <CardHeader title="Current Work Session" />
+                <Typography variant="h5" component="h2">
+                  {timerRunning ? formatTime(elapsedTime) : "00h 00m 00s"}
+                </Typography>
+              </CardContent>
+              <CardActions sx={{ justifyContent: "flex-end" }}>
+                {timerRunning ? (
+                  <Button onClick={stopTimer} color="error">
+                    Stop Timer
+                  </Button>
+                ) : (
+                  <Button onClick={startTimer}>Start Timer</Button>
+                )}
+              </CardActions>
+            </Card>
+          </div>
+        ) : (
+          // sorta hate how this looks
+          <Box
+            sx={{
+              position: "fixed",
+              bottom: 70,
+              left: 5,
+              padding: 1.5,
+              boxShadow: 3,
+              borderRadius: 4,
+              zIndex: 1000,
+              backgroundColor: "rgba(0, 0, 0, 0.5)",
+            }}
+          >
+            <Stack>
+              <Typography variant="caption">
+                {org?.name} - {proj?.name}
               </Typography>
-            </CardContent>
-            <CardActions sx={{ justifyContent: "flex-end" }}>
-              {timerRunning ? (
-                <Button onClick={stopTimer} color="error">
-                  Stop Timer
-                </Button>
-              ) : (
-                <Button onClick={startTimer}>Start Timer</Button>
-              )}
-            </CardActions>
-          </Card>
-        </div>
-      ) : (
-        // sorta hate how this looks
+              <Stack direction="row" alignItems="center" flex={1} justifyContent="space-between">
+                <Typography variant="body1">{timerRunning ? formatTime(elapsedTime) : "00h 00m 00s"}</Typography>
+                <IconButton color="inherit" size="small" onClick={timerRunning ? stopTimer : startTimer}>
+                  {timerRunning ? <StopIcon /> : <PlayArrowIcon />}
+                </IconButton>
+              </Stack>
+            </Stack>
+          </Box>
+        ))}
+      {appMode === "widget" && (
         <Box
           sx={{
+            display: "flex",
+            justifyContent: "flex-start",
+            alignItems: "center",
             position: "fixed",
-            bottom: 70,
-            left: 5,
-            padding: 1.5,
-            boxShadow: 3,
-            borderRadius: 4,
-            zIndex: 1000,
-            backgroundColor: "rgba(0, 0, 0, 0.5)",
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: "100%",
           }}
         >
-          <Stack>
-            <Typography variant="caption">
-              {org?.name} - {proj?.name}
-            </Typography>
-            <Stack direction="row" alignItems="center" flex={1} justifyContent="space-between">
-              <Typography variant="body1">{timerRunning ? formatTime(elapsedTime) : "00h 00m 00s"}</Typography>
-              <IconButton color="inherit" size="small" onClick={timerRunning ? stopTimer : startTimer}>
-                {timerRunning ? <StopIcon /> : <PlayArrowIcon />}
+          <Box sx={{ padding: 1.5 }}>
+            <Tooltip title="Open in normal mode" placement="right">
+              <IconButton sx={{ position: "absolute", top: -5, right: -5 }} onClick={maximize}>
+                <OpenInFull />
               </IconButton>
+            </Tooltip>
+            <Stack>
+              <Typography variant="caption">
+                {org?.name} - {proj?.name}
+              </Typography>
+              <Stack direction="row" alignItems="center" flex={1} justifyContent="space-between">
+                <Typography variant="body1">{timerRunning ? formatTime(elapsedTime) : "00h 00m 00s"}</Typography>
+                <IconButton color="inherit" size="small" onClick={timerRunning ? stopTimer : startTimer}>
+                  {timerRunning ? <StopIcon /> : <PlayArrowIcon />}
+                </IconButton>
+              </Stack>
             </Stack>
-          </Stack>
+          </Box>
         </Box>
       )}
     </>

--- a/frontend/src/components/AppFooter.tsx
+++ b/frontend/src/components/AppFooter.tsx
@@ -1,18 +1,20 @@
-import React, { useState, useEffect } from "react";
-import { AppBar, Toolbar, Typography, Tooltip, IconButton, Badge } from "@mui/material";
 import GitHubIcon from "@mui/icons-material/GitHub";
 import SystemUpdateIcon from "@mui/icons-material/SystemUpdate";
+import { AppBar, Badge, IconButton, Toolbar, Tooltip, Typography } from "@mui/material";
+import React, { useEffect, useState } from "react";
 
+import { useAppStore } from "@/stores/main";
 import { GetVersion, UpdateAvailable } from "../../wailsjs/go/main/App";
 import { EventsEmit, EventsOn } from "../../wailsjs/runtime/runtime";
-import ActiveSession from "./ActiveSession";
 import { useTimerStore } from "../stores/timer";
+import ActiveSession from "./ActiveSession";
 
 const AppFooter: React.FC<{}> = () => {
   const [version, setVersion] = useState("");
   const [updateAvailable, setUpdateAvailable] = useState(false);
   const stopTimer = useTimerStore((state) => state.stopTimer);
   const showMiniTimer = useTimerStore((state) => state.showMiniTimer);
+  const appMode = useAppStore((state) => state.appMode);
 
   EventsOn("update-available", () => {
     setUpdateAvailable(true);
@@ -26,6 +28,10 @@ const AppFooter: React.FC<{}> = () => {
     GetVersion().then(setVersion);
     UpdateAvailable().then(setUpdateAvailable);
   }, []);
+
+  if (appMode === "widget") {
+    return null;
+  }
 
   return (
     <AppBar position="fixed" color="primary" sx={{ top: "auto", bottom: 0 }}>

--- a/frontend/src/routes/App.tsx
+++ b/frontend/src/routes/App.tsx
@@ -56,6 +56,7 @@ function App() {
   // const renderCount = useRef(0);
   // renderCount.current += 1;
   // console.log("App rendered", renderCount.current);
+  const appMode = useAppStore((state) => state.appMode);
   const isScreenHeightLessThan510px = useMediaQuery("(max-height:510px)");
   const currentYear = new Date().getFullYear();
   const currentMonth = getMonth();
@@ -417,6 +418,10 @@ function App() {
       setProjWorkTotals(dayTotal, weekTotal, monthTotal);
     });
   }, [activeProj, projects]);
+
+  if (appMode === "widget") {
+    return <ActiveSession stopTimer={stopTimer} />;
+  }
 
   return (
     <div id="App">

--- a/frontend/src/stores/main.ts
+++ b/frontend/src/stores/main.ts
@@ -4,6 +4,8 @@ import { create } from "zustand";
 import { createJSONStorage, persist, subscribeWithSelector } from "zustand/middleware";
 
 interface Store {
+  appMode: "normal" | "widget";
+  setAppMode: (mode: "normal" | "widget") => void;
   organizations: main.Organization[];
   getOrganizations: () => main.Organization[];
   addOrganization: (organization: main.Organization) => void;
@@ -53,6 +55,11 @@ interface Store {
 export const useAppStore = create(
   persist(
     subscribeWithSelector<Store>((set, get) => ({
+      appMode: "normal",
+      setAppMode: (mode: "normal" | "widget") => {
+        if (mode === get().appMode) return;
+        set({ appMode: mode });
+      },
       organizations: [],
       getOrganizations: () => JSON.parse(JSON.stringify(get().organizations)),
       addOrganization: (organization: main.Organization) => {

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -51,9 +51,13 @@ export function GetYearlyWorkTime(arg1:number,arg2:number):Promise<number>;
 
 export function GetYearlyWorkTimeByProject(arg1:number,arg2:number):Promise<{[key: string]: number}>;
 
+export function MinimizeWindow():Promise<void>;
+
 export function NewOrganization(arg1:string,arg2:string):Promise<main.NewOrgRet>;
 
 export function NewProject(arg1:string,arg2:string):Promise<main.Project>;
+
+export function NormalizeWindow():Promise<void>;
 
 export function RenameOrganization(arg1:number,arg2:string):Promise<main.Organization>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -98,12 +98,20 @@ export function GetYearlyWorkTimeByProject(arg1, arg2) {
   return window['go']['main']['App']['GetYearlyWorkTimeByProject'](arg1, arg2);
 }
 
+export function MinimizeWindow() {
+  return window['go']['main']['App']['MinimizeWindow']();
+}
+
 export function NewOrganization(arg1, arg2) {
   return window['go']['main']['App']['NewOrganization'](arg1, arg2);
 }
 
 export function NewProject(arg1, arg2) {
   return window['go']['main']['App']['NewProject'](arg1, arg2);
+}
+
+export function NormalizeWindow() {
+  return window['go']['main']['App']['NormalizeWindow']();
 }
 
 export function RenameOrganization(arg1, arg2) {

--- a/main.go
+++ b/main.go
@@ -16,10 +16,12 @@ var assets embed.FS
 var WailsConfigFile []byte
 
 const (
-	WIN_HEIGHT    = 768
-	WIN_WIDTH     = 1024
-	WIDGET_HEIGHT = 100
-	WIDGET_WIDTH  = 300
+	WIN_HEIGHT     = 768
+	WIN_WIDTH      = 1024
+	MIN_WIN_HEIGHT = 560
+	MIN_WIN_WIDTH  = 925
+	WIDGET_HEIGHT  = 100
+	WIDGET_WIDTH   = 300
 )
 
 func main() {
@@ -32,9 +34,11 @@ func main() {
 
 	// Create application with options
 	err := wails.Run(&options.App{
-		Title:  appTitle,
-		Width:  WIN_WIDTH,
-		Height: WIN_HEIGHT,
+		Title:     appTitle,
+		Width:     WIN_WIDTH,
+		Height:    WIN_HEIGHT,
+		MinHeight: MIN_WIN_HEIGHT,
+		MinWidth:  MIN_WIN_WIDTH,
 		AssetServer: &assetserver.Options{
 			Assets: assets,
 		},

--- a/main.go
+++ b/main.go
@@ -15,6 +15,13 @@ var assets embed.FS
 //go:embed wails.json
 var WailsConfigFile []byte
 
+const (
+	WIN_HEIGHT    = 768
+	WIN_WIDTH     = 1024
+	WIDGET_HEIGHT = 100
+	WIDGET_WIDTH  = 300
+)
+
 func main() {
 	// Create an instance of the app structure
 	app := NewApp()
@@ -26,8 +33,8 @@ func main() {
 	// Create application with options
 	err := wails.Run(&options.App{
 		Title:  appTitle,
-		Width:  1024,
-		Height: 768,
+		Width:  WIN_WIDTH,
+		Height: WIN_HEIGHT,
 		AssetServer: &assetserver.Options{
 			Assets: assets,
 		},


### PR DESCRIPTION
### Description:
This PR implements a `widget` view of the active session timer. This allows users to dock it off to the side of their screen.

### 🧠 Rationale behind the change
Adding this features makes it easy to check our active time while working without having to pull up the whole window as it's usually minimized/hidden.

### Commits & Changes:
- `app.go`
  - Added `Normalize/Minimize` window methods https://github.com/theBGuy/go-work-tracker/commit/4eea55e1dd5d522a06c85dde1800e308e3a6d32c
- `frontend`
  - `stores/main.ts`
    - Added `appMode` state, 'normal' or 'widget'
  - `ActiveSession.tsx`
    - Added widget view
  - `App.tsx & AppFooter`
    - Hide components when widget view is active

### 📸 Screenshots (optional)
| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/32ec0017-0596-4a26-ad5f-e1dfb83015bd) | ![image](https://github.com/user-attachments/assets/a4263ca4-c7f4-4470-9d62-700010c4eb72) |

![image](https://github.com/user-attachments/assets/9aaa7042-5b2e-49b7-8f8b-bf8a58722d23)


### 🏎 Quality check

- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?

- [ ] Walk away, take a break, re-read what you filled out above does it make sense if you were coming in cold? What extra context could you provide?