### PR TITLE
[Hotfix] Fix `getWeekRange` method

### DIFF
--- a/db.go
+++ b/db.go
@@ -659,6 +659,7 @@ func (a *App) GetOrgWorkTimeByWeek(year int, month time.Month, week int, organiz
 		return 0, err
 	}
 	startOfWeek, endOfWeek := getWeekRange(year, month, week)
+	fmt.Printf("week %v startOfWeek: %s, endOfWeek: %s\n", week, startOfWeek, endOfWeek)
 
 	err = a.db.Table("work_hours").
 		Select("COALESCE(SUM(work_hours.seconds), 0)").

--- a/helpers.go
+++ b/helpers.go
@@ -257,6 +257,7 @@ func getWeekRange(year int, month time.Month, week int) (startOfWeek string, end
 			endOfWeek = currDay.Format("2006-01-02")
 			return startOfWeek, endOfWeek
 		}
+		currDay = currDay.AddDate(0, 0, 1)
 	}
 	return startOfWeek, endOfWeek
 }


### PR DESCRIPTION
### Description:
This PR fixes the `getWeekRange` to correctly iterate through weeks so we get the right start/end dates of the wanted work week.

### Commits & Changes:
- `helpers.go`
  - Fixed `getWeekRange` by incrementing date to continue for loop


### 🏎 Quality check

- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?

- [x] Walk away, take a break, re-read what you filled out above does it make sense if you were coming in cold? What extra context could you provide?