### PR TITLE
[Patch] Update main store to persist `alertTime` using localStorage

### DIFF
--- a/frontend/src/stores/main.ts
+++ b/frontend/src/stores/main.ts
@@ -117,9 +117,11 @@ export const useAppStore = create(
           activeProj: project,
         }));
       },
-      alertTime: 30,
+      alertTime: Number(localStorage.getItem("alertTime")) || 30,
       setAlertTime: (time: number) => {
         if (time === get().alertTime) return;
+        // temp fix so this value persists
+        localStorage.setItem("alertTime", time.toString());
         set({ alertTime: time });
       },
       workTime: 0,


### PR DESCRIPTION
### Description:
This PR allows the users chosen `alertTime` to persist across browser sessions by using localStorage

### 🧠 Rationale behind the change
Using localStorage for this was a much simpler solution than introducing a kv store like badger

### 🏎 Quality check

- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?

- [x] Walk away, take a break, re-read what you filled out above does it make sense if you were coming in cold? What extra context could you provide?