### PR TITLE
[Hotfix] Fix returning the correct seconds worked and default sort

### DIFF
--- a/db.go
+++ b/db.go
@@ -438,7 +438,7 @@ func (a *App) saveTimer(projectID uint) int {
 
 	a.lastSave = time.Now()
 
-	return secsWorked
+	return int(endTime.Sub(a.startTime).Seconds())
 }
 
 // GetWorkTime returns the total seconds worked on the specified date

--- a/frontend/src/routes/SessionsManager.tsx
+++ b/frontend/src/routes/SessionsManager.tsx
@@ -238,6 +238,9 @@ export default function SessionsManager() {
                 pageSize: 5,
               },
             },
+            sorting: {
+              sortModel: [{ field: "date", sort: "desc" }],
+            },
           }}
           slots={{ toolbar: GridToolbar }}
           slotProps={{ toolbar: { showQuickFilter: true } }}


### PR DESCRIPTION
### Description:
This PR fixes returning/setting the correct values for work sessions. 

### Commits & Changes:
- `db.go`
  - Fixed returning the correct elapsedTime from the saveTimer method
- `SessionsManager.tsx`
  - Default the sorting to have the newest sessions first

### 🏎 Quality check

- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?

- [x] Walk away, take a break, re-read what you filled out above does it make sense if you were coming in cold? What extra context could you provide?