### PR TITLE
[BugFix] Cleanup EventsOn listeners

### DIFF
--- a/frontend/src/components/AppFooter.tsx
+++ b/frontend/src/components/AppFooter.tsx
@@ -16,10 +16,6 @@ const AppFooter: React.FC<{}> = () => {
   const showMiniTimer = useTimerStore((state) => state.showMiniTimer);
   const appMode = useAppStore((state) => state.appMode);
 
-  EventsOn("update-available", () => {
-    setUpdateAvailable(true);
-  });
-
   const handleUpdate = () => {
     EventsEmit("do-update");
   };
@@ -27,6 +23,14 @@ const AppFooter: React.FC<{}> = () => {
   useEffect(() => {
     GetVersion().then(setVersion);
     UpdateAvailable().then(setUpdateAvailable);
+
+    const updateEvent = EventsOn("update-available", () => {
+      setUpdateAvailable(true);
+    });
+
+    return () => {
+      updateEvent();
+    };
   }, []);
 
   if (appMode === "widget") {

--- a/frontend/src/routes/App.tsx
+++ b/frontend/src/routes/App.tsx
@@ -114,11 +114,6 @@ function App() {
   const [editOrg, setEditOrg] = useState(0);
   const [editProj, setEditProj] = useState(0);
 
-  EventsOn("new-day", () => {
-    console.debug("New day event received");
-    setDateStr(dateString());
-  });
-
   const checkForUpdates = async () => {
     setShowSpinner(true);
     await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -353,6 +348,11 @@ function App() {
       }
     });
 
+    const newDayEvent = EventsOn("new-day", () => {
+      console.debug("New day event received");
+      setDateStr(dateString());
+    });
+
     const daySubscription = useAppStore.subscribe(
       (state) => state.dateStr,
       (curr, prev) => {
@@ -378,6 +378,7 @@ function App() {
     return () => {
       setShowMiniTimer(true);
       daySubscription(); // cleanup
+      newDayEvent(); // cleanup
       // renderCount.current = 0;
     };
   }, []);


### PR DESCRIPTION
### Description:
This PR fixes EventsOn being registered multiple times and never cleaned up.

### 🧠 Rationale behind the change
`EventsOn` being outside the useEffect hook was causing it to add another event listener every re-render. It should of been inside the hook so it only adds once and then gets cleaned up on unmount

### Commits & Changes:
- `AppFooter.tsx`
  - Moved `EventsOn("update-available")` into useEffect
- `App.tsx`
  - Moved `EventsOn("new-day")` into useEffect

### 🏎 Quality check

- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?

- [ ] Walk away, take a break, re-read what you filled out above does it make sense if you were coming in cold? What extra context could you provide?