### PR TITLE
[Chore] Cleanup store names + Fix desync with current work session time

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -58,7 +58,8 @@ let workTimeInterval: NodeJS.Timeout;
 let confirmationInterval: NodeJS.Timeout;
 const setElapsedTime = useTimerStore.getState().setElapsedTime;
 const setOpenConfirm = useTimerStore.getState().setOpenConfirm;
-const updateDayWorkTotals = useAppStore.getState().updateDayWorkTotals;
+const setOrgDayTotal = useAppStore.getState().setOrgDayTotal;
+const setProjDayTotal = useAppStore.getState().setProjDayTotal;
 const updateOrgWeekTotal = useAppStore.getState().updateOrgWeekTotal;
 const updateProjWeekTotal = useAppStore.getState().updateProjWeekTotal;
 const updateOrgMonthTotal = useAppStore.getState().updateOrgMonthTotal;
@@ -72,10 +73,13 @@ const timerSubscription = useTimerStore.subscribe(
   (curr, prev) => {
     console.log(`Time state switched from ${prev} to ${curr}`);
     if (curr) {
+      const orgTotal = useAppStore.getState().orgWeekTotal;
+      const projTotal = useAppStore.getState().projWeekTotal;
       workTimeInterval = setInterval(() => {
         TimeElapsed().then((currentElapsedTime) => {
           setElapsedTime(currentElapsedTime);
-          updateDayWorkTotals(1);
+          setOrgDayTotal(orgTotal + currentElapsedTime);
+          setProjDayTotal(projTotal + currentElapsedTime);
         });
       }, 1000);
       const alertTime = useAppStore.getState().alertTime;

--- a/frontend/src/routes/App.tsx
+++ b/frontend/src/routes/App.tsx
@@ -80,10 +80,10 @@ function App() {
   // Variables for timer
   const resetTimer = useTimerStore((state) => state.resetTimer);
   const timerRunning = useTimerStore((state) => state.running);
-  const workTime = useAppStore((state) => state.workTime);
-  const setWorkTime = useAppStore((state) => state.setWorkTime);
-  const currProjectWorkTime = useAppStore((state) => state.projectWorkTime);
-  const setCurrProjectWorkTime = useAppStore((state) => state.setProjectWorkTime);
+  const orgDayTotal = useAppStore((state) => state.orgDayTotal);
+  const setOrgDayTotal = useAppStore((state) => state.setOrgDayTotal);
+  const projDayTotal = useAppStore((state) => state.projDayTotal);
+  const setProjDayTotal = useAppStore((state) => state.setProjDayTotal);
 
   // Variables for handling work time totals
   const orgWeekTotal = useAppStore((state) => state.orgWeekTotal);
@@ -273,7 +273,7 @@ function App() {
           setSelectedProject(newSelectedProject);
 
           SetProject(newSelectedProject.id).then(() => {
-            GetWorkTimeByProject(newSelectedProject.id, dateString()).then(setCurrProjectWorkTime);
+            GetWorkTimeByProject(newSelectedProject.id, dateString()).then(setProjDayTotal);
           });
         }
       });
@@ -363,14 +363,14 @@ function App() {
         if (!org) return;
         GetWorkTime(curr, org.id).then((time) => {
           console.debug(`Work time for ${org.name}`, time);
-          setWorkTime(time);
+          setOrgDayTotal(time);
         });
 
         const proj = useAppStore.getState().activeProj;
         if (!proj) return;
         GetWorkTimeByProject(proj.id, curr).then((time) => {
           console.debug(`Work time for ${org.name}/${proj.name}`, time);
-          setCurrProjectWorkTime(time);
+          setProjDayTotal(time);
         });
       }
     );
@@ -567,9 +567,9 @@ function App() {
             <Grid item xs={12} sm={4} md={4}>
               <WorkTimeListing
                 title="Today's Work Total"
-                orgTotal={workTime}
+                orgTotal={orgDayTotal}
                 projName={activeProj?.name || ""}
-                projTotal={currProjectWorkTime}
+                projTotal={projDayTotal}
               />
             </Grid>
 

--- a/frontend/src/stores/main.ts
+++ b/frontend/src/stores/main.ts
@@ -25,11 +25,11 @@ interface Store {
   setActiveInfo: (organization: main.Organization, project: main.Project) => void;
   alertTime: number;
   setAlertTime: (time: number) => void;
-  workTime: number;
-  setWorkTime: (value: number) => void;
+  orgDayTotal: number;
+  setOrgDayTotal: (value: number) => void;
   updateWorkTime: (value: number) => void;
-  projectWorkTime: number;
-  setProjectWorkTime: (value: number) => void;
+  projDayTotal: number;
+  setProjDayTotal: (value: number) => void;
   updateProjectWorkTime: (value: number) => void;
   updateDayWorkTotals: (value: number) => void;
   orgWeekTotal: number;
@@ -129,22 +129,22 @@ export const useAppStore = create(
         localStorage.setItem("alertTime", time.toString());
         set({ alertTime: time });
       },
-      workTime: 0,
-      setWorkTime: (value: number) => {
-        if (value === get().workTime) return;
-        set({ workTime: value });
+      orgDayTotal: 0,
+      setOrgDayTotal: (value: number) => {
+        if (value === get().orgDayTotal) return;
+        set({ orgDayTotal: value });
       },
-      updateWorkTime: (value: number) => set((state) => ({ workTime: state.workTime + value })),
-      projectWorkTime: 0,
-      setProjectWorkTime: (value: number) => {
-        if (value === get().projectWorkTime) return;
-        set({ projectWorkTime: value });
+      updateWorkTime: (value: number) => set((state) => ({ orgDayTotal: state.orgDayTotal + value })),
+      projDayTotal: 0,
+      setProjDayTotal: (value: number) => {
+        if (value === get().projDayTotal) return;
+        set({ projDayTotal: value });
       },
-      updateProjectWorkTime: (value: number) => set((state) => ({ projectWorkTime: state.projectWorkTime + value })),
+      updateProjectWorkTime: (value: number) => set((state) => ({ projDayTotal: state.projDayTotal + value })),
       updateDayWorkTotals: (value: number) => {
         set((state) => ({
-          workTime: state.workTime + value,
-          projectWorkTime: state.projectWorkTime + value,
+          orgDayTotal: state.orgDayTotal + value,
+          projDayTotal: state.projDayTotal + value,
         }));
       },
       orgWeekTotal: 0,
@@ -182,23 +182,23 @@ export const useAppStore = create(
       },
       updateProjMonthTotal: (value: number) => set((state) => ({ projMonthTotal: state.projMonthTotal + value })),
       setProjWorkTimeTotals: (dayTime: number, weekTime: number, monthTime: number) => {
-        const currDay = get().projectWorkTime;
+        const currDay = get().projDayTotal;
         const currWeek = get().projWeekTotal;
         const currMonth = get().projMonthTotal;
         if (dayTime === currDay && weekTime === currWeek && monthTime === currMonth) return;
         set(() => ({
-          projectWorkTime: dayTime,
+          projDayTotal: dayTime,
           projWeekTotal: weekTime,
           projMonthTotal: monthTime,
         }));
       },
       setOrgWorkTimeTotals: (dayTime: number, weekTime: number, monthTime: number) => {
-        const currDay = get().workTime;
+        const currDay = get().orgDayTotal;
         const currWeek = get().orgWeekTotal;
         const currMonth = get().orgMonthTotal;
         if (dayTime === currDay && weekTime === currWeek && monthTime === currMonth) return;
         set(() => ({
-          workTime: dayTime,
+          orgDayTotal: dayTime,
           orgWeekTotal: weekTime,
           orgMonthTotal: monthTime,
         }));


### PR DESCRIPTION
### Description:
This PR is mostly cleanup of the main app store to keep naming convention clean. It also addresses a desynchronization that happened with the work session time displayed `(elapsedTime)` and the day work totals for organization and project.

### 🧠 Rationale behind the change
Changing the store variables to stick to the day/week/month naming convention made their values more clear at a glance. Changing from incrementing org/project day totals by 1 each interval to using the same value as elaspedTime keeps the values in sync.

### Commits & Changes:
- `main.ts`
  - Changed `workTime` -> `orgDayTotal`
  - Changed `setWorkTime` -> `setOrgDayTotal`
  - Changed `projectWorkTime` -> `projDayTotal`
  - Changed `setProjectWorkTime` -> `setProjDayTotal`
- `app.tsx`
  - Changed `workTime` -> `orgDayTotal`
  - Changed `setWorkTime` -> `setOrgDayTotal`
  - Changed `currProjectWorkTime` -> `projDayTotal`
  - Changed `setCurrProjectWorkTime` -> `setProjDayTotal`

### 🏎 Quality check

- [x] Are there any erroneous console logs, debuggers or leftover code in your changes?

- [ ] Walk away, take a break, re-read what you filled out above does it make sense if you were coming in cold? What extra context could you provide?