### PR TITLE
[Feat] Old theme toggle

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
+        "@mui/base": "^5.0.0-beta.40",
         "@mui/icons-material": "^6.0.1",
         "@mui/material": "^6.0.1",
         "@mui/x-charts": "^7.15.0",
@@ -633,6 +634,44 @@
         "node": ">=12"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
+      "integrity": "sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.7"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.10.tgz",
+      "integrity": "sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.7"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.1.tgz",
+      "integrity": "sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
+      "integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==",
+      "license": "MIT"
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
@@ -679,6 +718,38 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mui/base": {
+      "version": "5.0.0-beta.40",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.40.tgz",
+      "integrity": "sha512-I/lGHztkCzvwlXpjD2+SNmvNQvB4227xBXhISPjEaJUXGImOQ9f3D2Yj/T3KasSI/h0MLWy74X0J6clhPmsRbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@mui/types": "^7.2.14",
+        "@mui/utils": "^5.15.14",
+        "@popperjs/core": "^2.11.8",
+        "clsx": "^2.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
@@ -3174,6 +3245,36 @@
       "dev": true,
       "optional": true
     },
+    "@floating-ui/core": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
+      "integrity": "sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==",
+      "requires": {
+        "@floating-ui/utils": "^0.2.7"
+      }
+    },
+    "@floating-ui/dom": {
+      "version": "1.6.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.10.tgz",
+      "integrity": "sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==",
+      "requires": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.7"
+      }
+    },
+    "@floating-ui/react-dom": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.1.tgz",
+      "integrity": "sha512-4h84MJt3CHrtG18mGsXuLCHMrug49d7DFkU0RMIyshRveBeyV2hmV/pDaF2Uxtu8kgq5r46llp5E5FQiR0K2Yg==",
+      "requires": {
+        "@floating-ui/dom": "^1.0.0"
+      }
+    },
+    "@floating-ui/utils": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
+      "integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA=="
+    },
     "@jridgewell/gen-mapping": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
@@ -3211,6 +3312,20 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "@mui/base": {
+      "version": "5.0.0-beta.40",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.40.tgz",
+      "integrity": "sha512-I/lGHztkCzvwlXpjD2+SNmvNQvB4227xBXhISPjEaJUXGImOQ9f3D2Yj/T3KasSI/h0MLWy74X0J6clhPmsRbQ==",
+      "requires": {
+        "@babel/runtime": "^7.23.9",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@mui/types": "^7.2.14",
+        "@mui/utils": "^5.15.14",
+        "@popperjs/core": "^2.11.8",
+        "clsx": "^2.1.0",
+        "prop-types": "^15.8.1"
       }
     },
     "@mui/core-downloads-tracker": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
+    "@mui/base": "^5.0.0-beta.40",
     "@mui/icons-material": "^6.0.1",
     "@mui/material": "^6.0.1",
     "@mui/x-charts": "^7.15.0",

--- a/frontend/src/components/AppFooter.tsx
+++ b/frontend/src/components/AppFooter.tsx
@@ -1,8 +1,9 @@
 import GitHubIcon from "@mui/icons-material/GitHub";
 import SystemUpdateIcon from "@mui/icons-material/SystemUpdate";
-import { AppBar, Badge, IconButton, Toolbar, Tooltip, Typography } from "@mui/material";
+import { Badge, IconButton, Toolbar, Tooltip, Typography } from "@mui/material";
 import React, { useEffect, useState } from "react";
 
+import AppBar from "@/components/ui/AppBar";
 import { useAppStore } from "@/stores/main";
 import { useTimerStore } from "@/stores/timer";
 import { GetVersion, UpdateAvailable } from "@go/main/App";
@@ -43,7 +44,6 @@ const AppFooter: React.FC<{}> = () => {
   return (
     <AppBar position="fixed" color="primary" sx={{ top: "auto", bottom: 0 }}>
       <Toolbar>
-        {/* <ThemeModeSwitch value={appTheme === "light"} onChange={toggleAppTheme} /> */}
         <Tooltip title={`Toggle light/dark mode. Currently ${appTheme} mode`} placement="top-end">
           <IconButton color="inherit" onClick={toggleAppTheme}>
             {appTheme === "light" ? <DarkModeIcon /> : <LightModeIcon />}

--- a/frontend/src/components/styled/NumberInput.tsx
+++ b/frontend/src/components/styled/NumberInput.tsx
@@ -1,0 +1,178 @@
+import {
+  Unstable_NumberInput as BaseNumberInput,
+  NumberInputProps,
+  numberInputClasses,
+} from "@mui/base/Unstable_NumberInput";
+import { styled } from "@mui/system";
+import * as React from "react";
+
+export const NumberInput = React.forwardRef(function CustomNumberInput(
+  props: NumberInputProps,
+  ref: React.ForwardedRef<HTMLDivElement>
+) {
+  return (
+    <BaseNumberInput
+      slots={{
+        root: StyledInputRoot,
+        input: StyledInputElement,
+        incrementButton: StyledButton,
+        decrementButton: StyledButton,
+      }}
+      slotProps={{
+        incrementButton: {
+          children: "▴",
+        },
+        decrementButton: {
+          children: "▾",
+        },
+      }}
+      {...props}
+      ref={ref}
+    />
+  );
+});
+
+const blue = {
+  100: "#DAECFF",
+  200: "#80BFFF",
+  400: "#3399FF",
+  500: "#007FFF",
+  600: "#0072E5",
+  700: "#0059B2",
+};
+
+const grey = {
+  50: "#F3F6F9",
+  100: "#E5EAF2",
+  200: "#DAE2ED",
+  300: "#C7D0DD",
+  400: "#B0B8C4",
+  500: "#9DA8B7",
+  600: "#6B7A90",
+  700: "#434D5B",
+  800: "#303740",
+  900: "#1C2025",
+};
+
+const StyledInputRoot = styled("div")(
+  ({ theme }) => `
+  font-family: 'IBM Plex Sans', sans-serif;
+  font-weight: 400;
+  border-radius: 8px;
+  color: ${theme.palette.mode === "dark" ? grey[300] : grey[900]};
+  background: ${theme.palette.mode === "dark" ? grey[900] : "#fff"};
+  border: 1px solid ${theme.palette.mode === "dark" ? grey[700] : grey[200]};
+  box-shadow: 0px 2px 4px ${theme.palette.mode === "dark" ? "rgba(0,0,0, 0.5)" : "rgba(0,0,0, 0.05)"};
+  display: grid;
+  grid-template-columns: 1fr 19px;
+  grid-template-rows: 1fr 1fr;
+  overflow: hidden;
+  column-gap: 8px;
+  padding: 4px;
+
+  &.${numberInputClasses.focused} {
+    border-color: ${blue[400]};
+    box-shadow: 0 0 0 3px ${theme.palette.mode === "dark" ? blue[700] : blue[200]};
+  }
+
+  &:hover {
+    border-color: ${blue[400]};
+  }
+
+  // firefox
+  &:focus-visible {
+    outline: 0;
+  }
+`
+);
+
+const StyledInputElement = styled("input")(
+  ({ theme }) => `
+  font-size: 0.875rem;
+  font-family: inherit;
+  font-weight: 400;
+  line-height: 1.5;
+  grid-column: 1/2;
+  grid-row: 1/3;
+  color: ${theme.palette.mode === "dark" ? grey[300] : grey[900]};
+  background: inherit;
+  border: none;
+  border-radius: inherit;
+  padding: 8px 12px;
+  outline: 0;
+`
+);
+
+const StyledButton = styled("button")(
+  ({ theme }) => `
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: center;
+  align-items: center;
+  appearance: none;
+  padding: 0;
+  width: 19px;
+  height: 19px;
+  font-family: system-ui, sans-serif;
+  font-size: 0.875rem;
+  line-height: 1;
+  box-sizing: border-box;
+  background: ${theme.palette.mode === "dark" ? grey[900] : "#fff"};
+  border: 0;
+  color: ${theme.palette.mode === "dark" ? grey[300] : grey[900]};
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 120ms;
+
+  &:hover {
+    background: ${theme.palette.mode === "dark" ? grey[800] : grey[50]};
+    border-color: ${theme.palette.mode === "dark" ? grey[600] : grey[300]};
+    cursor: pointer;
+  }
+
+  &.${numberInputClasses.incrementButton} {
+    grid-column: 2/3;
+    grid-row: 1/2;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    border: 1px solid;
+    border-bottom: 0;
+    border-color: ${theme.palette.mode === "dark" ? grey[700] : grey[200]};
+    background: ${theme.palette.mode === "dark" ? grey[900] : grey[50]};
+    color: ${theme.palette.mode === "dark" ? grey[200] : grey[900]};
+
+    &:hover {
+      cursor: pointer;
+      color: #FFF;
+      background: ${theme.palette.mode === "dark" ? blue[600] : blue[500]};
+      border-color: ${theme.palette.mode === "dark" ? blue[400] : blue[600]};
+    }
+  }
+
+  &.${numberInputClasses.decrementButton} {
+    grid-column: 2/3;
+    grid-row: 2/3;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border: 1px solid;
+    border-color: ${theme.palette.mode === "dark" ? grey[700] : grey[200]};
+    background: ${theme.palette.mode === "dark" ? grey[900] : grey[50]};
+    color: ${theme.palette.mode === "dark" ? grey[200] : grey[900]};
+  }
+
+  &:hover {
+    cursor: pointer;
+    color: #FFF;
+    background: ${theme.palette.mode === "dark" ? blue[600] : blue[500]};
+    border-color: ${theme.palette.mode === "dark" ? blue[400] : blue[600]};
+  }
+
+  & .arrow {
+    transform: translateY(-1px);
+  }
+
+  & .arrow {
+    transform: translateY(-1px);
+  }
+`
+);

--- a/frontend/src/components/ui/AppBar.tsx
+++ b/frontend/src/components/ui/AppBar.tsx
@@ -1,0 +1,13 @@
+import { useAppStore } from "@/stores/main";
+import { AppBarProps, AppBar as BaseAppBar } from "@mui/material";
+
+const AppBar: React.FC<AppBarProps> = ({ children, ...props }) => {
+  const enableColorOnDarkMode = useAppStore((state) => state.enableColorOnDark);
+  return (
+    <BaseAppBar {...props} enableColorOnDark={enableColorOnDarkMode}>
+      {children}
+    </BaseAppBar>
+  );
+};
+
+export default AppBar;

--- a/frontend/src/routes/App.tsx
+++ b/frontend/src/routes/App.tsx
@@ -10,6 +10,7 @@ import ActiveSession from "@/components/ActiveSession";
 import EditProjectDialog from "@/components/EditProjectDialog";
 import ModelSelect from "@/components/ModelSelect";
 import NavBar from "@/components/NavBar";
+import AppBar from "@/components/ui/AppBar";
 import WorkTimeListing from "@/components/WorkTimeListing";
 import { useAppStore } from "@/stores/main";
 import { useTimerStore } from "@/stores/timer";
@@ -39,7 +40,6 @@ import AddCircleIcon from "@mui/icons-material/AddCircle";
 import MenuIcon from "@mui/icons-material/Menu";
 import SettingsIcon from "@mui/icons-material/Settings";
 import {
-  AppBar,
   Box,
   CircularProgress,
   Divider,

--- a/frontend/src/routes/Charts.tsx
+++ b/frontend/src/routes/Charts.tsx
@@ -1,10 +1,11 @@
 import NavBar from "@/components/NavBar";
+import AppBar from "@/components/ui/AppBar";
 import { useAppStore } from "@/stores/main";
 import { useTimerStore } from "@/stores/timer";
 import { formatTime, getMonth, months } from "@/utils/utils";
 import { GetDailyWorkTimeByMonth, GetProjects } from "@go/main/App";
 import { main } from "@go/models";
-import { AppBar, FormControl, InputLabel, MenuItem, Paper, Select, Stack, Toolbar } from "@mui/material";
+import { FormControl, InputLabel, MenuItem, Paper, Select, Stack, Toolbar } from "@mui/material";
 import { type AxisConfig } from "@mui/x-charts";
 import { LineChart } from "@mui/x-charts/LineChart";
 import { useEffect, useMemo, useState } from "react";

--- a/frontend/src/routes/SessionsManager.tsx
+++ b/frontend/src/routes/SessionsManager.tsx
@@ -1,4 +1,5 @@
 import NavBar from "@/components/NavBar";
+import AppBar from "@/components/ui/AppBar";
 import { useTimerStore } from "@/stores/timer";
 import { formatTime } from "@/utils/utils";
 import { DeleteWorkSession, GetWorkSessions, TransferWorkSession } from "@go/main/App";
@@ -6,7 +7,6 @@ import { main } from "@go/models";
 import Delete from "@mui/icons-material/Delete";
 import SwapHorizIcon from "@mui/icons-material/SwapHoriz";
 import {
-  AppBar,
   Box,
   Button,
   Dialog,

--- a/frontend/src/routes/Tables.tsx
+++ b/frontend/src/routes/Tables.tsx
@@ -1,13 +1,14 @@
-import { AppBar, Box, MenuItem, Select, Stack, Toolbar, Typography } from "@mui/material";
-import NavBar from "../components/NavBar";
-import WorkTimeAccordion from "../components/WorkTimeAccordian";
-import { useAppStore } from "../stores/main";
-import { useEffect, useState } from "react";
+import NavBar from "@/components/NavBar";
+import AppBar from "@/components/ui/AppBar";
+import { useAppStore } from "@/stores/main";
+import { handleSort } from "@/utils/utils";
 import { GetProjects } from "@go/main/App";
 import { main } from "@go/models";
 import StarIcon from "@mui/icons-material/Star";
 import StarBorderIcon from "@mui/icons-material/StarBorder";
-import { handleSort } from "../utils/utils";
+import { Box, MenuItem, Select, Stack, Toolbar, Typography } from "@mui/material";
+import { useEffect, useState } from "react";
+import WorkTimeAccordion from "../components/WorkTimeAccordian";
 
 function Tables() {
   const [activeOrganization, setActiveOrganization] = useState(useAppStore.getState().getActiveOrganization());

--- a/frontend/src/stores/main.ts
+++ b/frontend/src/stores/main.ts
@@ -9,6 +9,8 @@ interface Store {
   appTheme: "light" | "dark";
   setAppTheme: (theme: "light" | "dark") => void;
   toggleAppTheme: () => void;
+  enableColorOnDark: boolean;
+  toggleEnableColorOnDark: () => void;
   organizations: main.Organization[];
   getOrganizations: () => main.Organization[];
   addOrganization: (organization: main.Organization) => void;
@@ -73,6 +75,11 @@ export const useAppStore = create(
         const theme = get().appTheme === "dark" ? "light" : "dark";
         localStorage.setItem("appTheme", theme);
         set({ appTheme: theme });
+      },
+      enableColorOnDark: JSON.parse(localStorage.getItem("enableColorOnDark") ?? "false"),
+      toggleEnableColorOnDark: () => {
+        localStorage.setItem("enableColorOnDark", JSON.stringify(!get().enableColorOnDark));
+        set((state) => ({ enableColorOnDark: !state.enableColorOnDark }));
       },
       organizations: [],
       getOrganizations: () => JSON.parse(JSON.stringify(get().organizations)),


### PR DESCRIPTION
### Description:
This PR adds a setting `enableColorOnDark` which toggles the AppBars color from dark gray to light blue.

### 🧠 Rationale behind the change
The colored mode more closely resembles the original styling.

### Commits & Changes:
- `main.ts`
  - Added `enableColorOnDark` state + toggleMethod that is persisted to localStorage
- `SettingsDialog.tsx`
  - Swapped out old select dropdown for confirmation interval setting to use the new `NumberInput` component
  - Added checkbox toggle for enabling color on dark mode (affects AppBar, was the orignal styling)
  - Removed close/save action buttons. Added close icon in top right corner and saving whenever there are changes instead of waiting for form submit

### 📸 Screenshots (optional)

__Before__
![image](https://github.com/user-attachments/assets/00863e6d-7c80-41f5-b995-7f06271a7231)

__After__
![image](https://github.com/user-attachments/assets/7c4ea0b5-ac99-4211-ba65-26af4b1ba3ce)

__Color Disabled__
![image](https://github.com/user-attachments/assets/b3f08e5a-8cdd-4ec1-b980-ee4f60125ac8)

__Color Enabled__
![image](https://github.com/user-attachments/assets/8b921b45-86d4-4059-80c8-0c377c6e153c)

### 🏎 Quality check

- [ ] Are there any erroneous console logs, debuggers or leftover code in your changes?

- [ ] Walk away, take a break, re-read what you filled out above does it make sense if you were coming in cold? What extra context could you provide?